### PR TITLE
Refactor the build system with the new Makefile.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "BeVolt/stlink"]
+	path = BeVolt/stlink
+	url = https://github.com/texane/stlink.git

--- a/BeVolt/Drivers/src/EEPROM.c
+++ b/BeVolt/Drivers/src/EEPROM.c
@@ -10,7 +10,7 @@
 #include "Voltage.h"
 #include "Temperature.h"
 #include "UART.h"
-#include "Systick.h"
+#include "SysTick.h"
 #include <stdio.h>
 
 //starting addresses for errors

--- a/BeVolt/Makefile
+++ b/BeVolt/Makefile
@@ -69,7 +69,7 @@ endif
 HEX = $(CP) -O ihex
 BIN = $(CP) -O binary -S
 
-SF = st-flash
+SF = ./stlink/build/Release/st-flash
  
 #######################################
 # CFLAGS
@@ -170,7 +170,7 @@ $(BUILD_DIR):
 	mkdir $@		
 
 #######################################
-# clean up
+# clean up. Just the program files though
 #######################################
 clean:
 	-rm -fR $(BUILD_DIR)
@@ -180,7 +180,14 @@ clean:
 # flash
 #######################################
 flash: $(BUILD_DIR)/$(TARGET).bin
+	cd stlink && $(MAKE)
 	$(SF) write $(BUILD_DIR)/$(TARGET).bin 0x8000000
+
+#######################################
+# clean everything, including the stlink
+#######################################
+clean-all: clean
+	cd stlink && $(MAKE) clean
 
 #######################################
 # dependencies

--- a/BeVolt/Makefile
+++ b/BeVolt/Makefile
@@ -114,7 +114,7 @@ C_INCLUDES =  \
 # compile gcc flags
 ASFLAGS = $(MCU) $(AS_DEFS) $(AS_INCLUDES) $(OPT) -Wall -fdata-sections -ffunction-sections
 
-CFLAGS = $(MCU) $(C_DEFS) $(C_INCLUDES) $(OPT) -Wall -fdata-sections -ffunction-sections
+CFLAGS = $(MCU) $(C_DEFS) $(USER_DEFS) $(C_INCLUDES) $(OPT) -Wall -fdata-sections -ffunction-sections
 
 ifeq ($(DEBUG), 1)
 CFLAGS += -g3 -gdwarf-2

--- a/BeVolt/solar-build
+++ b/BeVolt/solar-build
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# This file is used to streamline the build of the BPS.
+# To use this file, call it via ./solar-build.sh from a
+# bash shell while in the same directory.
+
+# check for too many arguments
+if [ $# -gt 1 ] 
+  then
+    echo "Got more arguments than expected."
+    echo "Not doing anything."
+    
+    exit 1
+fi
+
+# Update the timestamp on the main.c file so that make
+# will rebuild that without needing to rebuild everything.
+touch $(find . -iname main.c)
+
+# inform if no arguments were provided
+if [ -z "$1" ] 
+  then
+    echo "No arguments were supplied."
+    echo "Building the default configuration"
+
+    # build without any arguments
+    make
+
+    exit 0
+fi
+
+if [ "$1" = "clean" ] 
+  then
+    echo "Cleaning..."
+
+    make clean
+
+    exit 0
+fi
+
+# make the stuff
+make USER_DEFS:="-D$1"

--- a/BeVolt/solar-build
+++ b/BeVolt/solar-build
@@ -1,42 +1,21 @@
 #!/bin/bash
 
 # This file is used to streamline the build of the BPS.
-# To use this file, call it via ./solar-build.sh from a
-# bash shell while in the same directory.
-
-# check for too many arguments
-if [ $# -gt 1 ] 
-  then
-    echo "Got more arguments than expected."
-    echo "Not doing anything."
-    
-    exit 1
-fi
+# This now just looks for a few special arguments, and
+# if it doesn't see any, it will instead just pass the
+# arguments along to Make.
 
 # Update the timestamp on the main.c file so that make
 # will rebuild that without needing to rebuild everything.
 touch $(find . -iname main.c)
 
-# inform if no arguments were provided
-if [ -z "$1" ] 
-  then
-    echo "No arguments were supplied."
-    echo "Building the default configuration"
-
-    # build without any arguments
-    make
+# check for test arguments
+if [ "$1" = "test" ]
+then
+    echo "Running test program '$2'. "
+    make USER_DEFS:="-D$2"
 
     exit 0
 fi
 
-if [ "$1" = "clean" ] 
-  then
-    echo "Cleaning..."
-
-    make clean
-
-    exit 0
-fi
-
-# make the stuff
-make USER_DEFS:="-D$1"
+make "$@"

--- a/README.md
+++ b/README.md
@@ -2,12 +2,35 @@
 This repo contains all code related to UTSVT's Battery Protection System
 
 ## Setup
+There are two options for developing the BPS system. One option is to use the
+Keil IDE, which includes some basic debugging tools. The other option is to
+use a terminal in a linux environment to build and flash the program.
+
+### Setup for Keil Development
+There is a tool called Keil that ARM produces for development on its microcontrollers.
 Download the most recent version of the Keil IDE: https://www.keil.com/demo/eval/arm.htm
 
-## Rules
-Commit frequently into your own branches. Create a Pull Request whenever you are ready to add you working code to the master branch. You must select 1 reviewer for approval. Follow the coding guidelines in the Solar Google Drive. The reviewers will make sure everything is up to par with the coding standards.
+### Setup for Terminal Development
+The system can also be built and deployed from a terminal, allowing you to use different
+development tools than Keil.
 
-Reviewers: (More will be added)
+1. Ensure that you either have Ubuntu installed or have the windows subsystem for linux installed.
+2. Install the `gcc-arm-none-eabi` package via `sudo apt install gcc-arm-none-eabi`.
+3. Go the the directory with the `Makefile` via your terminal.
+4. Type `make`. If the thing does not compile, try a `make clean` and then repeat `make`.
+5. Celebrate your independence from Keil.
+
+In order to compile a specific test case, you can run the `solar-build` script with the name of the
+test case. For example, `./solar-build CAN_TEST_2`.
+
+## Rules
+Commit frequently into your own branches. Create a Pull Request whenever you are ready to add 
+your working code to the master branch. You must select at least 1 reviewer for approval. 
+Follow the coding guidelines in the Solar Google Drive. The reviewers will make sure everything 
+is up to par with the coding standards. Expect them to ask you about parts of your code if they
+need clarification on anything.
+
+Reviewers:
 1. Sijin Woo
 2. Chase Block
 3. Clark Poon


### PR DESCRIPTION
Overview
========
This commit extends upon the introduction of the Linux
Makefile to make the build-system much cleaner. This is
done by:

1. Moving the "real" `main()` in `main.c` to be located at
the bottom of the file. In addition, the systemLoop function
was introduced at the top of the file for basic organization.
2. The creation of the `solar-build` script, which negates the
need to have the definition for the test that we want to run
in the actual files. In this way, we can build multiple targets
without needing to modify files.
3. Updating the README.md with instructions on how to get the
new build system working on a bash shell (assuming a Debian/Ubuntu
installation).
4. Fixing up some minor things to get the thing to build right.