### PR TITLE
fixed Current_CheckStatus

### DIFF
--- a/BeVolt/App/inc/Current.h
+++ b/BeVolt/App/inc/Current.h
@@ -11,6 +11,7 @@
 #include <stdint.h>
 #include "ADC.h"
 #include "config.h"
+#include <stdbool.h>
  
 /** Current_Init
  * Initializes two ADCs to begin current monitoring.
@@ -27,7 +28,7 @@ ErrorStatus Current_UpdateMeasurements(void);
  * Checks if pack does not have a short circuit
  * @return SAFE or DANGER
  */
-SafetyStatus Current_CheckStatus(void);
+SafetyStatus Current_CheckStatus(bool override);
 
 /** Current_IsCharging
  * Determines if the the battery pack is being charged or discharged depending on

--- a/BeVolt/App/inc/config.h
+++ b/BeVolt/App/inc/config.h
@@ -35,6 +35,7 @@ typedef enum {SAFE = 0, DANGER = 1, OVERVOLTAGE = 2, UNDERVOLTAGE = 3} SafetySta
 
 #define MAX_CURRENT_LIMIT				100		// Max current limit (Amperes)		(Max continuous discharge is 15A per cell)
 #define MAX_HIGH_PRECISION_CURRENT 		50		// Max current detectable by the high-precision current sensor
+#define MAX_CHARGING_CURRENT -20		//Max current per cell is 1.5 Amps (Standard charge)
 
 //--------------------------------------------------------------------------------
 // Helpers

--- a/BeVolt/App/src/Current.c
+++ b/BeVolt/App/src/Current.c
@@ -41,17 +41,16 @@ ErrorStatus Current_UpdateMeasurements(void){
  * Checks if pack does not have a short circuit
  * @return SAFE or DANGER
  */
-SafetyStatus Current_CheckStatus(void){
+SafetyStatus Current_CheckStatus(bool override){
 
-	if(HighPrecisionCurrent > MAX_HIGH_PRECISION_CURRENT) {
-		return (LowPrecisionCurrent < MAX_CURRENT_LIMIT)
-			? SAFE
-			: DANGER;
-	} else {
+	//if((LowPrecisionCurrent < MAX_CURRENT_LIMIT)&&(!override))
+	if((LowPrecisionCurrent > MAX_CHARGING_CURRENT)&&(LowPrecisionCurrent < MAX_CURRENT_LIMIT)&&(!override))
 		return SAFE;
-	}
+	else if((LowPrecisionCurrent <= 0)&&(LowPrecisionCurrent > MAX_CHARGING_CURRENT)&&override)
+		return SAFE;
+	else
+		return DANGER;
 }
-
 /** Current_IsCharging
  * Determines if the the battery pack is being charged or discharged depending on
  * the sign of the current
@@ -59,7 +58,7 @@ SafetyStatus Current_CheckStatus(void){
  */
 int8_t Current_IsCharging(void){
 	// TODO: Make sure that the current board is installed in such a way that negative => charging
-	return HighPrecisionCurrent < 0;
+	return LowPrecisionCurrent < 0;
 }
 
 /** Current_GetHighPrecReading

--- a/BeVolt/App/src/Current.c
+++ b/BeVolt/App/src/Current.c
@@ -43,7 +43,6 @@ ErrorStatus Current_UpdateMeasurements(void){
  */
 SafetyStatus Current_CheckStatus(bool override){
 
-	//if((LowPrecisionCurrent < MAX_CURRENT_LIMIT)&&(!override))
 	if((LowPrecisionCurrent > MAX_CHARGING_CURRENT)&&(LowPrecisionCurrent < MAX_CURRENT_LIMIT)&&(!override))
 		return SAFE;
 	else if((LowPrecisionCurrent <= 0)&&(LowPrecisionCurrent > MAX_CHARGING_CURRENT)&&override)

--- a/BeVolt/App/src/main.c
+++ b/BeVolt/App/src/main.c
@@ -40,7 +40,7 @@ int realmain(){
 		// Update battery percentage
 		SoC_Calculate(Current_GetLowPrecReading());
 		
-		SafetyStatus current = Current_CheckStatus();
+		SafetyStatus current = Current_CheckStatus(override);
 		SafetyStatus temp = Temperature_CheckStatus(Current_IsCharging());
 		SafetyStatus voltage = Voltage_CheckStatus();
 
@@ -113,7 +113,7 @@ void faultCondition(void){
 
 	uint8_t error = 0;
 
-	if(!Current_CheckStatus()){
+	if(!Current_CheckStatus(false)){
 		error |= FAULT_HIGH_CURRENT;
 		LED_On(OCURR);
 	}
@@ -203,6 +203,7 @@ void faultCondition(void){
 //		following:
 //		#define LTC6811_TEST
 #define CAN_TEST_2
+#define Current_CheckStatus_Test
 
 #ifdef Systick_TEST
 
@@ -379,7 +380,7 @@ int main(){
 		printf("\n\r==============================\n\rCurrent Test:\n\r");
 		printf("ADC High: %d\n\r", ADC_ReadHigh());
 		printf("ADC Low: %d\n\r", ADC_ReadLow());
-		printf("Is the battery safe? %d\n\r", Current_CheckStatus());
+		printf("Is the battery safe? %d\n\r", Current_CheckStatus(false));
 		printf("Is the battery charging? %d\n\r", Current_IsCharging());
 		printf("High: %d\n\r", Current_GetHighPrecReading());
 		printf("Low: %d\n\r", Current_GetLowPrecReading());
@@ -660,6 +661,27 @@ void DischargingSoCTest(void) {
 /** Tests
  * 	TODO: Need to test SetAccumulator, GetPercent and Calibrate on faults
  */
+
+#elif defined Current_CheckStatus_Test
+#include "uart.h"
+extern int32_t LowPrecisionCurrent;
+
+int main() {
+	int32_t LowPrecisionTestValue = -60;
+	int8_t LoopNum = 20;
+	UART3_Init();
+	printf("0 means SAFE, 1 means DANGER\n\r\n\r");
+	while(LoopNum>0){
+		LowPrecisionTestValue+=10;
+		LoopNum-=1;
+		//Current_UpdateMeasurements();
+		LowPrecisionCurrent = LowPrecisionTestValue;
+		printf("TestCurrent = %d \n\r", LowPrecisionCurrent);
+		printf("Override Off yields %d \n\r", Current_CheckStatus(false));
+		printf("Override Set yields %d \n\r", Current_CheckStatus(true));
+		printf("\n\r");
+}
+}
 
 #elif defined EEPROM_WRITE_TEST
 
@@ -946,7 +968,7 @@ int main(void) {
 	
 	Current_UpdateMeasurements();
 	
-	if (Current_CheckStatus() == SAFE){
+	if (Current_CheckStatus(override) == SAFE){
 		printf("current is safe\n\r");
 	}else{
 		printf("current is not safe\n\r");


### PR DESCRIPTION
Current_CheckStatus checks that LowPrecisionCurrent is within safe limits based on whether or not override is set - now takes boolean override as input -- test added to main.c to print output of SAFE or DANGER based on LowPrecisionCurrent value & override parameter