### PR TITLE
Renames handler to generic name in BSP Template

### DIFF
--- a/BeVolt/BSP/Simulator/Src/BSP_UART.c
+++ b/BeVolt/BSP/Simulator/Src/BSP_UART.c
@@ -40,7 +40,7 @@ void BSP_UART_Init(void) {
  */
 uint32_t BSP_UART_ReadLine(char *str) {
     if(lineReceived) {
-        // TODO: Disble UART Receive interrupts HERE
+        // TODO: Disable UART Receive interrupts HERE
         uint8_t data = 0;
         RxFifo_Peek(&data);
         while(!RxFifo_IsEmpty() && data != '\r') {
@@ -53,7 +53,7 @@ uint32_t BSP_UART_ReadLine(char *str) {
         *str = 0;
 
         lineReceived = false;
-        // TODO: Disble UART Receive interrupts HERE
+        // TODO: Enable UART Receive interrupts HERE
         return true;
     }
 

--- a/BeVolt/BSP/Template/Src/BSP_UART.c
+++ b/BeVolt/BSP/Template/Src/BSP_UART.c
@@ -78,7 +78,7 @@ uint32_t BSP_UART_Write(char *str, uint32_t len) {
 }
 
 
-void USART3_IRQHandler(void) {
+void Interrupt_Handler(void) {
     // TODO: Check for Receive Interrupt
     if(0) {
 


### PR DESCRIPTION
BSP_UART in Template had UART3_IRQHandler as the interrupt handler name but Template should have a generic name that needs to be edited by the user whenever a new chip is implemented.