### PR TITLE
Fault Condition Fix

### DIFF
--- a/BeVolt/Apps/Src/main.c
+++ b/BeVolt/Apps/Src/main.c
@@ -61,6 +61,8 @@ int main(){
 			break;
 		}
 
+		// TODO: Implement heartbeat for RUN light at a visible frequency
+
 		// Update necessary
 		// CAN_SendMessageStatus()	// Most likely need to put this on a timer if sending too frequently
 
@@ -117,7 +119,7 @@ void initialize(void){
  */
 void preliminaryCheck(void){
 	// Check if Watch dog timer was triggered previously
-	if (BSP_WDTimer_DidSystemReset() == DANGER) {
+	if (BSP_WDTimer_DidSystemReset()) {
 		BSP_Light_On(FAULT);
 		BSP_Light_On(WDOG);
 		while(1);		// Spin
@@ -136,12 +138,12 @@ void faultCondition(void){
 
 	uint8_t error = 0;
 
-	if(!Current_CheckStatus(false)){
+	if(Current_CheckStatus(false) != SAFE){
 		error |= FAULT_HIGH_CURRENT;
 		BSP_Light_On(OCURR);
 	}
 
-	if(!Voltage_CheckStatus()){
+	if(Voltage_CheckStatus() != SAFE){
 		// Toggle Voltage fault LED
 		switch(Voltage_CheckStatus()){
 			case OVERVOLTAGE:
@@ -164,9 +166,9 @@ void faultCondition(void){
 		}
 	}
 
-	if(!Temperature_CheckStatus(Current_IsCharging())){
+	if(Temperature_CheckStatus(Current_IsCharging()) != SAFE){
 		error |= FAULT_HIGH_TEMP;
-		BSP_Light_On(OCURR);
+		BSP_Light_On(OTEMP);
 	}
 
 	// Log all the errors that we have
@@ -215,3 +217,4 @@ void faultCondition(void){
 					// causing WDOG error. WDTimer can't be stopped after it starts.
 	}
 }
+	


### PR DESCRIPTION
Previously, the Status functions for Voltage, Current, and Temperature returned different values, but now they return SAFE or DANGER. The checks were logging errors in the event that these checks returned SAFE, not DANGER as they were supposed to. This caused the incorrect error lights to be turned on and incorrect errors to be logged in the EEPROM. 