### PR TITLE
I2 c simulator

### DIFF
--- a/BeVolt/BSP/Inc/BSP_I2C.h
+++ b/BeVolt/BSP/Inc/BSP_I2C.h
@@ -3,6 +3,8 @@
 
 #include "common.h"
 
+#define EEPROM_BYTES 16384
+
 /**
  * @brief   Initializes the I2C port that interfaces with the EEPROM.
  * @param   None

--- a/BeVolt/BSP/Simulator/Src/BSP_I2C.c
+++ b/BeVolt/BSP/Simulator/Src/BSP_I2C.c
@@ -75,6 +75,19 @@ uint8_t BSP_I2C_Read(uint8_t deviceAddr, uint16_t regAddr, uint8_t *rxData, uint
     // TODO: Get the data from the other device/IC.
     //      The I2C bus has only two lines, the Clock and Data pins. The process for reading data
     //      is to first transmit the regAddr then immediately read.
-
-    return 0;
+    if (deviceAddr != EEPROM_ADDRESS){
+        return ERROR;//fail because device address is incorrect
+    }
+    FILE *fp = fopen(file, "r");
+    fseek(fp, regAddr * CSV_ENTRY_LENGTH, SEEK_SET);//set file pointer to starting EEPROM address in csv file
+    char data[5];//want to include "0x" prefix
+    data[4] = '\0';
+    for (uint32_t i = 0; i < rxLen; i++){
+        char *end;//needed for strtol
+        fscanf(fp, "%c%c%c%c", &(data[0]), &(data[1]), &(data[2]), &(data[3]));
+        rxData[i] = (uint8_t) strtol(data, &end, 16);
+        fseek(fp, CSV_ENTRY_LENGTH - 4, SEEK_CUR);//iterate to next "address" in csv file
+    }
+    fclose(fp);
+    return SUCCESS;
 }

--- a/BeVolt/BSP/Simulator/Src/BSP_I2C.c
+++ b/BeVolt/BSP/Simulator/Src/BSP_I2C.c
@@ -1,13 +1,37 @@
 #include "BSP_I2C.h"
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+//only supports EEPROM peripheral (as of May 2020, the EEPROM is the only peripheral on the I2C bus)
+
+//path for EEPROM file
+static const char* file = "BSP/Simulator/DataGeneration/Data/EEPROM.csv";
 
 /**
- * @brief   Initializes the I2C port that interfaces with the EEPROM.
+ * @brief   Initializes the I2C port that interfaces with the EEPROM. Creates EEPROM csv file if it does not already exist
  * @param   None
  * @return  None
  */
 void BSP_I2C_Init(void) {
-    // TODO: Initialize the I2C pins connected to the EEPROM.
-    //      By default, the code assumes the I2C bus is running at 100kHz
+    //create and initialize csv file to simulate EEPROM if it does not exist already
+    char hex[3];//to hold first 2 characters of file
+    //open and close file (to prevent seg fault if file does not exist)
+    FILE *fp = fopen(file, "a");
+    fclose(fp);
+    //check if first 2 characters in file are equal to "0x", if not, reinitialize EEPROM
+    fp = fopen(file, "r");
+    fgets(hex, 3, fp);
+    fclose(fp);
+    //if csv file does not exist (or has incorrect format of first element), initialize csv file EEPROM with all 0s
+    if (strcmp(hex, "0x")){
+        fp = fopen(file, "w");
+        for (uint32_t i = 0; i < (EEPROM_BYTES - 1); i++){
+            fprintf(fp, "0x00,");
+        }
+        fprintf(fp, "0x00");
+    }
+    fclose(fp);
 }
 
 /**

--- a/BeVolt/BSP/Simulator/Src/BSP_I2C.c
+++ b/BeVolt/BSP/Simulator/Src/BSP_I2C.c
@@ -21,7 +21,7 @@ static const char* file = "BSP/Simulator/DataGeneration/Data/EEPROM.csv";
 void BSP_I2C_Init(void) {
     //create and initialize csv file to simulate EEPROM if it does not exist already
     char hex[3];//to hold first 2 characters of file
-    //open and close file (to prevent seg fault if file does not exist)
+    //open and close file (to create file if it does not exist)
     FILE *fp = fopen(file, "a");
     fclose(fp);
     //check if first 2 characters in file are equal to "0x", if not, reinitialize EEPROM
@@ -72,9 +72,6 @@ uint8_t  BSP_I2C_Write(uint8_t deviceAddr, uint16_t regAddr, uint8_t *txData, ui
  * @return  error status, 0 if fail, 1 if success
  */
 uint8_t BSP_I2C_Read(uint8_t deviceAddr, uint16_t regAddr, uint8_t *rxData, uint32_t rxLen) {
-    // TODO: Get the data from the other device/IC.
-    //      The I2C bus has only two lines, the Clock and Data pins. The process for reading data
-    //      is to first transmit the regAddr then immediately read.
     if (deviceAddr != EEPROM_ADDRESS){
         return ERROR;//fail because device address is incorrect
     }

--- a/BeVolt/BSP/Simulator/Src/BSP_I2C.c
+++ b/BeVolt/BSP/Simulator/Src/BSP_I2C.c
@@ -2,6 +2,10 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include "EEPROM.h"
+
+#define CSV_ENTRY_LENGTH 5  //"0x??," is 5 characters
+#define CSV_ENTRY_OFFSET 2  //"0x" is 2 characters
 
 //only supports EEPROM peripheral (as of May 2020, the EEPROM is the only peripheral on the I2C bus)
 
@@ -44,7 +48,18 @@ void BSP_I2C_Init(void) {
  */
 uint8_t  BSP_I2C_Write(uint8_t deviceAddr, uint16_t regAddr, uint8_t *txData, uint32_t txLen) {
     // TODO: Transmit the data onto the I2C bus. Packet the data as needed.
-
+    if (deviceAddr != EEPROM_ADDRESS){
+        return 0;//fail because device address is incorrect
+    }
+    FILE *fp = fopen(file, "r+");
+    fseek(fp, regAddr * CSV_ENTRY_LENGTH + CSV_ENTRY_OFFSET, SEEK_SET);
+    char data[3];
+    for (uint32_t i = 0; i < txLen; i++){
+        sprintf(data, "%x", txData[i]);//convert uint8_t to char[]
+        fprintf(fp, "%c%c", data[0], data[1]);
+        fseek(fp, CSV_ENTRY_LENGTH - 2 /*subtract 2, since 2 bytes were written*/, SEEK_CUR);
+    }
+    fclose(fp);
     return 0;
 }
 

--- a/BeVolt/BSP/Simulator/Src/BSP_I2C.c
+++ b/BeVolt/BSP/Simulator/Src/BSP_I2C.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include "EEPROM.h"
+#include "config.h"
 
 #define CSV_ENTRY_LENGTH 5  //"0x??," is 5 characters
 #define CSV_ENTRY_OFFSET 2  //"0x" is 2 characters
@@ -47,20 +48,19 @@ void BSP_I2C_Init(void) {
  * @return  error status, 0 if fail, 1 if success
  */
 uint8_t  BSP_I2C_Write(uint8_t deviceAddr, uint16_t regAddr, uint8_t *txData, uint32_t txLen) {
-    // TODO: Transmit the data onto the I2C bus. Packet the data as needed.
     if (deviceAddr != EEPROM_ADDRESS){
-        return 0;//fail because device address is incorrect
+        return ERROR;//fail because device address is incorrect
     }
     FILE *fp = fopen(file, "r+");
-    fseek(fp, regAddr * CSV_ENTRY_LENGTH + CSV_ENTRY_OFFSET, SEEK_SET);
+    fseek(fp, regAddr * CSV_ENTRY_LENGTH + CSV_ENTRY_OFFSET, SEEK_SET);//set file pointer to starting EEPROM address in csv file
     char data[3];
     for (uint32_t i = 0; i < txLen; i++){
-        sprintf(data, "%x", txData[i]);//convert uint8_t to char[]
+        sprintf(data, "%x", txData[i]);//convert uint8_t to char[], so that it can be written to csv file
         fprintf(fp, "%c%c", data[0], data[1]);
-        fseek(fp, CSV_ENTRY_LENGTH - 2 /*subtract 2, since 2 bytes were written*/, SEEK_CUR);
+        fseek(fp, CSV_ENTRY_LENGTH - 2 /*subtract 2, since 2 bytes were written*/, SEEK_CUR);//iterate to next "address" in csv file
     }
     fclose(fp);
-    return 0;
+    return SUCCESS;
 }
 
 /**

--- a/BeVolt/Tests/Test_BSP_I2C.c
+++ b/BeVolt/Tests/Test_BSP_I2C.c
@@ -1,0 +1,13 @@
+#include "common.h"
+#include "config.h"
+#include "BSP_I2C.h"
+#include "EEPROM.h"
+
+int main() {
+	BSP_I2C_Init();
+	printf("EEPROM initialized\n");
+	uint8_t buffer[4] = {0xfe, 0xed, 0xbe, 0xef};
+	EEPROM_WriteMultipleBytes(0x0000, 4, buffer);
+	return 0;
+}
+

--- a/BeVolt/Tests/Test_BSP_I2C.c
+++ b/BeVolt/Tests/Test_BSP_I2C.c
@@ -3,11 +3,24 @@
 #include "BSP_I2C.h"
 #include "EEPROM.h"
 
+#define ADDRESS 0x0005
+
 int main() {
 	BSP_I2C_Init();
 	printf("EEPROM initialized\n");
 	uint8_t buffer[4] = {0xfe, 0xed, 0xbe, 0xef};
-	EEPROM_WriteMultipleBytes(0x0000, 4, buffer);
+	EEPROM_WriteMultipleBytes(ADDRESS, 4, buffer);
+	uint8_t readBuffer[4];
+	BSP_I2C_Read(EEPROM_ADDRESS, ADDRESS, readBuffer, 4);
+	printf("read EEPROM\n");
+	for (int i = 0; i < 4; i++){
+		printf("%x\n", readBuffer[i]);
+	}
+	printf("--------------------\n");
+	EEPROM_Reset();
+	EEPROM_Load();
+	EEPROM_Tester();
+	EEPROM_SerialPrintData();
 	return 0;
 }
 


### PR DESCRIPTION
Added support for EEPROM (via BSP_I2C.c) to the simulator. EEPROM is simulated as a text file where each address is separated by a '\n' character, so the EEPROM can be easily read using a text editor. The simulated EEPROM can also be written to and read from using the functions in EEPROM.c and BSP_I2C.c