### PR TITLE
Fix the Makefile's flash and clean functionalities.

### DIFF
--- a/BeVolt/Makefile
+++ b/BeVolt/Makefile
@@ -22,6 +22,9 @@ simulator:
 stm32f413:
 	$(MAKE) -C BSP -C STM32F413
 
+flash:
+	$(MAKE) -C BSP -C STM32F413 flash
+
 help:
 	@echo "Format: ${ORANGE}make ${BLUE}<BSP type>${NC}${ORANGE}TEST=${PURPLE}<Test type>${NC}"
 	@echo "BSP types (required):"
@@ -38,4 +41,4 @@ help:
 
 clean:
 	rm -fR Objects
-	rm *.out
+	rm -f *.out


### PR DESCRIPTION
Problem
=======
This has been bugging me. Clean should not spit out
error messages unless something has actually gone wrong.
A file not being there when it needs to be removed is
a non-problem.

This was also missing the ability to flash to the board.

Solution
========
It's pretty simple changes. Take a look yourself.