### PR TITLE
CLI Temperature Bugfix

### DIFF
--- a/BeVolt/Config/Inc/config.h
+++ b/BeVolt/Config/Inc/config.h
@@ -13,6 +13,7 @@ typedef enum {ERROR = 0, SUCCESS = !ERROR} ErrorStatus;
 typedef enum {SAFE = 0, DANGER = 1, OVERVOLTAGE = 2, UNDERVOLTAGE = 3} SafetyStatus;
 
 // NUCLEO or custom
+#define COMMAND_SIZE			128
 #define NUCLEO		0		// Change 1 if using nucleo, 0 if not
 
 //--------------------------------------------------------------------------------


### PR DESCRIPTION
**Problem**: The CLI was inaccurately getting sensor data from the Temperature library, so the display was incorrect
**Solution**: Correctly calculate the boardNum and sensorNum for each user input that matches with the layout of the ModuleTemperatures array in the Temperature library