### PR TITLE
fixed compiler warning

### DIFF
--- a/BeVolt/Apps/Src/CLI.c
+++ b/BeVolt/Apps/Src/CLI.c
@@ -394,7 +394,7 @@ void setLED(Light input, int state) {
  */
 void CLI_LED(int* hashTokens) {
 	State error = BSP_Light_GetState(FAULT);
-	if((int *)hashTokens[1] == NULL) {
+	if(hashTokens[1] == 0) {
 		if(error == ON) {
 			printf("Error light is On\n\r");
 		} else {


### PR DESCRIPTION
An integer to pointer of wrong size cast was causing a compiler warning. I fixed it by using integers instead of pointers