### PR TITLE
Make a launch script to streamline simulator use.

### DIFF
--- a/BeVolt/BSP/Simulator/DataGeneration/simulate.py
+++ b/BeVolt/BSP/Simulator/DataGeneration/simulate.py
@@ -142,10 +142,18 @@ def main():
                     stdscr = curses.initscr()
                     curses.start_color()
         except Exception as e:
+            curses.echo()
+            curses.nocbreak()
+            curses.endwin()
             print("ERROR:", end=" ")
             print(e, end="\r\n")
             print("If addwstr() returned ERR, make your terminal window bigger.")
-            break
+            print("\n\rContinue? (Y/n): ", end="")
+            cont = input()
+            if(cont.lower() == "n" or cont.lower() == "no"):
+                break
+            print("Continuing...")
+            main()
     curses.echo()
     curses.nocbreak()
     curses.endwin()

--- a/BeVolt/BSP/Simulator/Src/BSP_I2C.c
+++ b/BeVolt/BSP/Simulator/Src/BSP_I2C.c
@@ -35,8 +35,8 @@ void BSP_I2C_Init(void) {
             fprintf(fp, "0x00\n");
         }
         fprintf(fp, "0x00");
+        fclose(fp);
     }
-    fclose(fp);
 }
 
 /**

--- a/BeVolt/simulate
+++ b/BeVolt/simulate
@@ -2,7 +2,7 @@
 # Run this to begin the simulation.
 
 function simulate() {
-    cd "$(dirname "$0")/BSP/Simulator/DataGeneration/"
+    cd "$(dirname "$0")"
     
     # Do a quick check for operating system.
     # Right now, the only linux shell that is supported is gnome-terminal,
@@ -10,13 +10,11 @@ function simulate() {
     if [[ $(uname -a | grep Microsoft) ]]; then
         echo "Launching a new WSL shell..."
         # This line makes me sad
-        cmd.exe /c start cmd.exe /c wsl.exe python3 simulate.py &
+        cmd.exe /c start cmd.exe /c "mode con: cols=103 lines=33 && wsl.exe python3 BSP/Simulator/DataGeneration/simulate.py" &
     else
         echo "Launching gnome-terminal..."
-        gnome-terminal --working-directory="$(pwd)" --geometry=103x33 -- python3 simulate.py  
+        gnome-terminal --working-directory="$(pwd)" --geometry=103x33 -- python3 BSP/Simulator/DataGeneration/simulate.py  
     fi
-    
-    cd "../../../"
 
     ./bps-simulator.out
 }

--- a/BeVolt/simulate
+++ b/BeVolt/simulate
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Run this to begin the simulation.
+
+function simulate() {
+    cd "$(dirname "$0")/BSP/Simulator/DataGeneration/"
+    
+    # Do a quick check for operating system.
+    # Right now, the only linux shell that is supported is gnome-terminal,
+    # since that's the default on Ubuntu.
+    if [[ $(uname -a | grep Microsoft) ]]; then
+        echo "Launching a new WSL shell..."
+        # This line makes me sad
+        cmd.exe /c start cmd.exe /c wsl.exe python3 simulate.py &
+    else
+        echo "Launching gnome-terminal..."
+        gnome-terminal --working-directory="$(pwd)" --geometry=103x33 -- python3 simulate.py  
+    fi
+    
+    cd "../../../"
+
+    ./bps-simulator.out
+}
+
+simulate

--- a/BeVolt/simulate.py
+++ b/BeVolt/simulate.py
@@ -1,1 +1,0 @@
-BSP/Simulator/DataGeneration/simulate.py


### PR DESCRIPTION
This change addresses the following issues:

- Right now, we have to do two things to get the simulator fully running (launch the C and Python separately). Since this really is one simulator, it should be easier to launch.
- We have been using symlinks to start the python portion, but this seems to break when put into git (probably a result of changing file systems regularly)

Existing issues:

The first time that this script is launched on a fresh clone, it may not work properly, since the python script must be put into simulation mode before the simulator can begin. Since the python script is spawned as a separate process, this cannot be regulated by the script after launch. My suggestion is that we consider moving the file initialization (creating the ADC.csv, etc.) to either this launch script or the beginning of simulate.py. Even moving the file creation to the beginning of simulate.py may create a race-condition, so the better option is almost certainly placing it in the initialization script. I'm not sure if there was a specific reason for placing the file creation after the start of the simulation, so I have not made the necessary change with regards to this issue, but running the script once, beginning the python simulation, and then restarting the simulator is a workaround for now.

Clark was also not able to launch this on his WSL instance, but I'm unclear as to the exact problem, so I would suggest that the reviewer test this before approving.

This also only supports gnome-terminal as far as linux operating systems go. As far as I can tell, there is no good way to tell what the default terminal emulator is on a given system, so I just decided to use the one that is default on many distributions. You can still launch the script from something else, but it will open gnome-terminal for execution of simulator.py.