### PR TITLE
Display simulator errors.

### DIFF
--- a/BSP/Simulator/DataGeneration/simulate.py
+++ b/BSP/Simulator/DataGeneration/simulate.py
@@ -15,6 +15,7 @@ import Timer
 
 import os
 import sys
+import traceback
 
 # Global configurations
 state = ''  # Charging/Discharging
@@ -259,4 +260,9 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    try:
+        main()
+    except:
+        traceback.print_exc()
+        while True:
+            pass


### PR DESCRIPTION
Made it so that the Python part of the simulator will freeze and show the error message instead of crashing if there is an error. This way, if someone adds an error to the code, they can see where the error is.