### PR TITLE
CAN Interrupts and OS Integration

### DIFF
--- a/BSP/Inc/BSP_CAN.h
+++ b/BSP/Inc/BSP_CAN.h
@@ -5,10 +5,11 @@
 
 /**
  * @brief   Initializes the CAN module that communicates with the rest of the electrical system.
- * @param   None
+ * @param   rxEvent : the function to execute when recieving a message. NULL for no action.
+ * @param   txEnd   : the function to execute after transmitting a message
  * @return  None
  */
-void BSP_CAN_Init(void);
+void BSP_CAN_Init(void (*rxEvent)(void), void (*txEnd)(void));
 
 /**
  * @brief   Transmits the data onto the CAN bus with the specified id

--- a/BSP/STM32F413/Src/BSP_CAN.c
+++ b/BSP/STM32F413/Src/BSP_CAN.c
@@ -1,23 +1,87 @@
 #include "BSP_CAN.h"
 #include "stm32f4xx.h"
+#include "os.h"
 
 #define CAN_MODE        CAN_Mode_Normal
 
-static CanTxMsg TxMessage;
-static CanRxMsg RxMessage;
+// Queue functions
 
-static bool RxFlag = false;
+typedef struct _msg {
+    uint32_t id;
+    uint8_t data[8];
+} msg_t;
+
+#define QUEUE_SIZE 10
+typedef struct _queue {
+    msg_t msgs[QUEUE_SIZE];
+    
+    uint8_t head;
+    uint8_t tail;
+} queue_t;
+
+static queue_t gRxQueue = {
+    {0},
+    0,
+    0,
+    true
+};
+
+// Return 0 if failure
+static uint8_t QueuePut(queue_t *target, msg_t *msg) {
+    // Check to see if the queue is full
+    if((target->head + 1) % QUEUE_SIZE == target->tail) {
+        return 0;
+    }
+
+    // Add the msg to the queue
+    target->msgs[target->head] = *msg;
+    
+    target->head = (target->head + 1) % QUEUE_SIZE;
+
+    return 1;
+}
+
+// Return 0 if failure
+static uint8_t QueueGet(queue_t *target, msg_t *msg) {
+    // Check if the queue is empty
+    if(target->head == target->tail) {
+        return 0;
+    }
+
+    // Get the msg from the queue
+    *msg = target->msgs[target->tail];
+
+    target->tail = (target->tail + 1) % QUEUE_SIZE;
+
+    return 1;
+}
+
+// End Queue Functions
+
+// CAN BSP
+
+static CanTxMsg gTxMessage;
+static CanRxMsg gRxMessage;
+
+// User parameters for CAN events
+static void (*gRxEvent)(void);
+static void (*gTxEnd)(void);
 
 /**
  * @brief   Initializes the CAN module that communicates with the rest of the electrical system.
- * @param   None
+ * @param   rxEvent : the function to execute when recieving a message. NULL for no action.
+ * @param   txEnd   : the function to execute after transmitting a message. NULL for no action.
  * @return  None
  */
-void BSP_CAN_Init(void) {
+void BSP_CAN_Init(void (*rxEvent)(void), void (*txEnd)(void)) {
     GPIO_InitTypeDef GPIO_InitStructure;
     CAN_InitTypeDef CAN_InitStructure;
     NVIC_InitTypeDef NVIC_InitStructure;
     CAN_FilterInitTypeDef CAN_FilterInitStructure;
+
+    // Configure event handles
+    gRxEvent  = rxEvent;
+    gTxEnd    = txEnd;
 
     /* CAN GPIOs configuration **************************************************/
 
@@ -75,17 +139,17 @@ void BSP_CAN_Init(void) {
     CAN_FilterInit(CAN1, &CAN_FilterInitStructure);
 
     /* Transmit Structure preparation */
-    TxMessage.ExtId = 0x1;
-    TxMessage.RTR = CAN_RTR_DATA;
-    TxMessage.IDE = CAN_ID_STD;
-    TxMessage.DLC = 1;
+    gTxMessage.ExtId = 0x1;
+    gTxMessage.RTR = CAN_RTR_DATA;
+    gTxMessage.IDE = CAN_ID_STD;
+    gTxMessage.DLC = 1;
 
     /* Receive Structure preparation */
-    RxMessage.StdId = 0x00;
-    RxMessage.ExtId = 0x00;
-    RxMessage.IDE = CAN_ID_STD;
-    RxMessage.DLC = 0;
-    RxMessage.FMI = 0;
+    gRxMessage.StdId = 0x00;
+    gRxMessage.ExtId = 0x00;
+    gRxMessage.IDE = CAN_ID_STD;
+    gRxMessage.DLC = 0;
+    gRxMessage.FMI = 0;
 
     /* Enable FIFO 0 message pending Interrupt */
     CAN_ITConfig(CAN1, CAN_IT_FMP0, ENABLE);
@@ -96,6 +160,15 @@ void BSP_CAN_Init(void) {
     NVIC_InitStructure.NVIC_IRQChannelSubPriority = 0x0;
     NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
     NVIC_Init(&NVIC_InitStructure);	
+
+    if(NULL != txEnd) {
+        // Enable Tx Interrupts
+        NVIC_InitStructure.NVIC_IRQChannel = CAN1_TX_IRQn;
+        NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 0x0; // TODO: assess both of these priority settings
+        NVIC_InitStructure.NVIC_IRQChannelSubPriority = 0x0;
+        NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
+        NVIC_Init(&NVIC_InitStructure);
+    }
 }
 
 /**
@@ -106,12 +179,16 @@ void BSP_CAN_Init(void) {
  * @return  0 if module was unable to transmit the data onto the CAN bus. Any other value indicates data was transmitted.
  */
 uint8_t BSP_CAN_Write(uint32_t id, uint8_t data[8], uint8_t length) {
-    TxMessage.StdId = id;
-    TxMessage.DLC = length;
+    
+    gTxMessage.StdId = id;
+    gTxMessage.DLC = length;
 	for(int i = 0; i < length; i++){
-        TxMessage.Data[i] = data[i];
-	}
-	return CAN_Transmit(CAN1, &TxMessage);
+        gTxMessage.Data[i] = data[i];
+    }
+	
+    uint8_t retVal = CAN_Transmit(CAN1, &gTxMessage);
+
+    return retVal;
 }
 
 /**
@@ -123,23 +200,60 @@ uint8_t BSP_CAN_Write(uint32_t id, uint8_t data[8], uint8_t length) {
  * @return  0 if nothing was received so ignore id and data that was received. Any other value indicates data was received and stored.
  */
 uint8_t BSP_CAN_Read(uint32_t *id, uint8_t *data) {
-    if(RxFlag){
-		for(int i = 0; i < 8; i++){
-			data[i] = RxMessage.Data[i];
-		}
-        *id = RxMessage.StdId;
-		RxFlag = false;
-		return 1;
-	}
-    return 0;
+    // If the queue is empty, return err
+    if(gRxQueue.head == gRxQueue.tail) {
+        return 0;
+    }
+    
+    // Get the message
+    msg_t msg;
+    QueueGet(&gRxQueue, &msg);
+
+    // Transfer the message to the provided pointers
+    for(int i = 0; i < 8; i++){
+        data[i] = msg.data[i];
+    }
+    *id = msg.id;
+
+    return 1;
 }
 
-void CAN1_RX0_IRQHandler(void)
-{
-    CAN_Receive(CAN1, CAN_FIFO0, &RxMessage);
+void CAN1_RX0_IRQHandler(void) {
+    asm("CPSID I");   // Disable Interrupts
+    OSIntEnter();     // Signal to uC/OS
+    asm("CPSIE I");   // Re-enable interrupts
+    
+    // Take any pending messages into a queue
+    while(CAN_MessagePending(CAN1, CAN_FIFO0)) {
+        CAN_Receive(CAN1, CAN_FIFO0, &gRxMessage);
 
-    if ((RxMessage.StdId == 0x001)&&(RxMessage.IDE == CAN_ID_STD) && (RxMessage.DLC == 1)){
-        // TODO: do stuff
-        RxFlag = true;
+        msg_t rxMsg;
+        rxMsg.id = gRxMessage.StdId;
+        memcpy(&rxMsg.data[0], gRxMessage.Data, 8);
+
+        // Place the message in the queue
+        if(QueuePut(&gRxQueue, &rxMsg)) {
+            // If the queue was not already full...
+            // Call the driver-provided function, if it is not null
+            if(gRxEvent != NULL) {
+                gRxEvent();
+            }
+        }
     }
+
+    OSIntExit();      // Signal to uC/OS
+}
+
+void CAN1_TX_IRQHandler(void) {
+    asm("CPSID I");   // Disable Interrupts
+    OSIntEnter();     // Signal to uC/OS
+    asm("CPSIE I");   // Re-enable interrupts
+
+    // Acknowledge 
+    CAN_ClearFlag(CAN1, CAN_FLAG_RQCP0 | CAN_FLAG_RQCP1 | CAN_FLAG_RQCP2);
+
+    // Call the function provided
+    gTxEnd();
+
+    OSIntExit();      // Signal to uC/OS
 }

--- a/Drivers/Inc/CANbus.h
+++ b/Drivers/Inc/CANbus.h
@@ -39,10 +39,39 @@ typedef struct {
 void CANbus_Init(void);
 
 /**
- * @brief   Transmits data onto the CANbus
+ * @brief   Transmits data onto the CANbus.
+ *          This is non-blocking and will fail with an error if
+ * 			the CAN mailboxes are fully occupied. Be sure to
+ * 			check the return code or call CANbus_BlockAndSend.
  * @param   id : CAN id of the message
  * @param   payload : the data that will be sent.
+ * @return  0 if data wasn't sent, otherwise it was sent.
  */
 int CANbus_Send(CANId_t id, CANPayload_t payload);
+
+/**
+ * @brief   Transmits data onto the CANbus. If there are no mailboxes available,
+ *          this will put the thread to sleep until there are.
+ * @param   id : CAN id of the message
+ * @param   payload : the data that will be sent.
+ * @return  0 if error, a non-negative value otherwise
+ */
+int CANbus_BlockAndSend(CANId_t id, CANPayload_t payload);
+
+/**
+ * @brief   Receives data from the CAN bus. This is a non-blocking operation.
+ * @param   id : pointer to id variable
+ * @param   buffer : pointer to payload buffer
+ * @return  0 if there was no message, 1 otherwise.
+ */
+int CANbus_Receive(CANId_t *id, uint8_t *buffer);
+
+/**
+ * @brief   Waits for data to arrive.
+ * @param   id : pointer to id variable
+ * @param   buffer : pointer to payload buffer
+ * @return  0 if there was an error, 1 otherwise.
+ */
+int CANbus_WaitToReceive(CANId_t *id, uint8_t *buffer);
 
 #endif

--- a/Drivers/Src/CANbus.c
+++ b/Drivers/Src/CANbus.c
@@ -1,7 +1,46 @@
 #include "CANbus.h"
 #include "BSP_CAN.h"
+#include "os.h"
 
-static void floatTo4Bytes(uint8_t f, uint8_t bytes[4]);
+/* Locking mechanism for the CAN bus.
+ * 
+ * The mutexes gate access to the BSP layer.
+ * 
+ * The mail sem4 counts the number of mailboxes
+ * in use, so that we can block if we can't get
+ * a hold of one.
+ * 
+ * The receive sem4 counts the number of messages
+ * currently in the receiving queue.
+ */
+static OS_MUTEX CANbus_TxMutex;
+static OS_MUTEX CANbus_RxMutex;
+static OS_SEM	CANbus_MailSem4;
+static OS_SEM	CANbus_ReceiveSem4;
+
+/**
+ * @brief   Releases hold of the mailbox semaphore.
+ * @note	Do not call directly.
+ */
+static void CANbus_Release(void) {
+	OS_ERR err;
+
+	OSSemPost(&CANbus_MailSem4,
+			  OS_OPT_POST_1,
+			  &err);
+}
+
+/**
+ * @brief	Increments the receive semaphore.
+ * @note	Do not call directly.
+ */
+static void CANbus_CountIncoming(void) {
+	OS_ERR err;
+
+	OSSemPost(&CANbus_ReceiveSem4,
+			  OS_OPT_POST_1,
+			  &err);
+}
 
 /**
  * @brief   Initializes the CAN system
@@ -9,67 +48,217 @@ static void floatTo4Bytes(uint8_t f, uint8_t bytes[4]);
  * @return  None
  */
 void CANbus_Init(void) {
-    BSP_CAN_Init();
+	OS_ERR err;
+
+	OSMutexCreate(&CANbus_TxMutex,
+				  "CAN TX Lock",
+				  &err);
+
+	OSMutexCreate(&CANbus_RxMutex,
+				  "CAN RX Lock",
+				  &err);
+
+	OSSemCreate(&CANbus_MailSem4,
+                "CAN Mailbox Semaphore",
+                3,	// Number of mailboxes
+                &err);
+
+	OSSemCreate(&CANbus_ReceiveSem4,
+                "CAN Queue Counter Semaphore",
+                0,
+                &err);
+
+	// Initialize and pass interrupt hooks
+    BSP_CAN_Init(CANbus_CountIncoming, CANbus_Release);
+}
+
+// Static method, call CANbus_Send or CANbus_BlockAndSend instead
+static int CANbus_SendMsg(CANId_t id, CANPayload_t payload) {
+	uint8_t txdata[5];
+	uint8_t data_length = 0;
+	
+	OS_ERR err;
+	CPU_TS ts;
+
+	// TODO: is it really best to keep the list of
+	//		 valid messages to be sending in the driver?
+	switch (id) {
+		// Handle messages with one byte of data
+		case TRIP:
+		case ALL_CLEAR:
+		case CONTACTOR_STATE:
+		case WDOG_TRIGGERED:
+		case CAN_ERROR:
+			data_length = 1;
+			memcpy(txdata, &payload.data.b, sizeof(payload.data.b));
+			break;
+
+		// Handle messages with float data
+		case CURRENT_DATA:
+		case SOC_DATA:
+			data_length = 4;
+			memcpy(txdata, &payload.data.f, sizeof(payload.data.f));
+			break;
+
+		// Handle messages with idx + float data
+		case VOLT_DATA:
+		case TEMP_DATA:
+			data_length = 5;
+			txdata[0] = payload.idx;
+			memcpy(&txdata[1], &payload.data.f, sizeof(payload.data.f));
+			break;
+
+		// Handle invalid messages
+		default:
+			return 0;	// Do nothing if invalid
+	}
+
+	// The mutex is require to access the CAN bus.
+	// This is because the software is responsible for
+	// choosing the mailbox to put the message into,
+	// leaving a possible race condition if not protected.
+	OSMutexPend(&CANbus_TxMutex,
+				0,
+				OS_OPT_PEND_BLOCKING,
+				&ts,
+				&err);
+
+	// Write the data to the bus
+	uint8_t retVal = BSP_CAN_Write(id, txdata, data_length);
+
+	OSMutexPost(&CANbus_TxMutex,
+				OS_OPT_POST_1,
+				&err);
+
+	return retVal;
 }
 
 /**
- * @brief   Transmits data onto the CANbus
+ * @brief   Transmits data onto the CANbus. If there are no mailboxes available,
+ *          this will put the thread to sleep until there are.
+ * @param   id : CAN id of the message
+ * @param   payload : the data that will be sent.
+ * @return  0 if error, a non-negative value otherwise
+ */
+int CANbus_BlockAndSend(CANId_t id, CANPayload_t payload) {
+	CPU_TS ts;
+	OS_ERR err;
+
+	// Pend for a mailbox (blocking)
+	OSSemPend(&CANbus_MailSem4,
+			  0,
+			  OS_OPT_PEND_BLOCKING,
+			  &ts,
+			  &err);
+
+	// Check the error code
+	if(err != OS_ERR_NONE) {
+		return 0;
+	}
+
+	return CANbus_SendMsg(id, payload);
+}
+
+/**
+ * @brief   Transmits data onto the CANbus.
+ *          This is non-blocking and will fail with an error if
+ * 			the CAN mailboxes are fully occupied. Be sure to
+ * 			check the return code or call CANbus_BlockAndSend.
  * @param   id : CAN id of the message
  * @param   payload : the data that will be sent.
  * @return  0 if data wasn't sent, otherwise it was sent.
  */
 int CANbus_Send(CANId_t id, CANPayload_t payload) {
-    uint8_t txdata[5];
+    CPU_TS ts;
+	OS_ERR err;
 	
-	switch (id) {
-		case TRIP:
-			return BSP_CAN_Write(id, &payload.data.b, 1);
+	// Check to see if a mailbox is available
+	OSSemPend(&CANbus_MailSem4,
+			  0,
+			  OS_OPT_PEND_NON_BLOCKING,
+			  &ts,
+			  &err);
 
-		case ALL_CLEAR:
-			return BSP_CAN_Write(id, &payload.data.b, 1);
-
-		case CONTACTOR_STATE:
-			return BSP_CAN_Write(id, &payload.data.b, 1);
-
-		case CURRENT_DATA:
-			floatTo4Bytes(payload.data.f, &txdata[0]);
-			return BSP_CAN_Write(id, txdata, 4);
-
-		case VOLT_DATA:
-		case TEMP_DATA:
-			txdata[0] = payload.idx;
-			floatTo4Bytes(payload.data.f, &txdata[1]);
-			return BSP_CAN_Write(id, txdata, 5);
-
-		case SOC_DATA:
-			floatTo4Bytes(payload.data.f, &txdata[0]);
-			return BSP_CAN_Write(id, txdata, 4);
-
-		case WDOG_TRIGGERED:
-			return BSP_CAN_Write(id, &payload.data.b, 1);
-
-		case CAN_ERROR:
-			return BSP_CAN_Write(id, &payload.data.b, 1);
+	// Check to see if the semaphore was acquired successfully
+	if(err != OS_ERR_NONE) {
+		return 0;
 	}
-	return 0;
+
+	// Send the message
+	return CANbus_SendMsg(id, payload);
 }
 
+static int CANbus_GetMsg(CANId_t *id, uint8_t *buffer) {
+	CPU_TS ts;
+	OS_ERR err;
+	
+	// The mutex is require to access the CAN receive queue.
+	OSMutexPend(&CANbus_RxMutex,
+				0,
+				OS_OPT_PEND_BLOCKING,
+				&ts,
+				&err);
 
-static void floatTo4Bytes(uint8_t val, uint8_t bytes_array[4]) {
-	uint8_t temp;
-	// Create union of shared memory space
-	union {
-			float float_variable;
-			uint8_t temp_array[4];
-	} u;
-	// Overite bytes of union with float variable
-	u.float_variable = val;
-	// Assign bytes to input array
-	memcpy(bytes_array, u.temp_array, 4);
-	temp = bytes_array[3];
-	bytes_array[3] = bytes_array[0];
-	bytes_array[0] = temp;
-	temp = bytes_array[2];
-	bytes_array[2] = bytes_array[1];
-	bytes_array[1] = temp;	
+	// Write the data to the bus
+	uint32_t id_int;
+	uint8_t retVal = BSP_CAN_Read(&id_int, buffer);
+
+	*id = id_int;
+
+	OSMutexPost(&CANbus_RxMutex,
+				OS_OPT_POST_1,
+				&err);
+
+	return retVal;
+}
+
+/**
+ * @brief   Receives data from the CAN bus. This is a non-blocking operation.
+ * @param   id : pointer to id variable
+ * @param   buffer : pointer to payload buffer
+ * @return  0 if there was no message, 1 otherwise.
+ */
+int CANbus_Receive(CANId_t *id, uint8_t *buffer) {
+	CPU_TS ts;
+	OS_ERR err;
+	
+	// Check to see if a mailbox is available
+	OSSemPend(&CANbus_ReceiveSem4,
+			  0,
+			  OS_OPT_PEND_NON_BLOCKING,
+			  &ts,
+			  &err);
+
+	// Check to see if the semaphore was acquired successfully
+	if(err != OS_ERR_NONE) {
+		return 0;
+	}
+
+	// Send the message
+	return CANbus_GetMsg(id, buffer);
+}
+
+/**
+ * @brief   Waits for data to arrive.
+ * @param   id : pointer to id variable
+ * @param   buffer : pointer to payload buffer
+ * @return  0 if there was an error, 1 otherwise.
+ */
+int CANbus_WaitToReceive(CANId_t *id, uint8_t *buffer) {
+	CPU_TS ts;
+	OS_ERR err;
+
+	// Pend for a mailbox (blocking)
+	OSSemPend(&CANbus_ReceiveSem4,
+			  0,
+			  OS_OPT_PEND_BLOCKING,
+			  &ts,
+			  &err);
+
+	// Check the error code
+	if(err != OS_ERR_NONE) {
+		return 0;
+	}
+
+	return CANbus_GetMsg(id, buffer);
 }


### PR DESCRIPTION
Problem
=======
The CAN driver and BSP code was previously using polling-like
techniques to send and receive messages. This will not integrate
well with the move to uC/OS.

Solution
========
The CAN drivers are being moved to an interrupt-driven system,
whereby the receiving messages come via interrupt for later collection,
and the transmitted messages utilize interrupts and locks to ensure
thread safety.

There are now two methods for transmitting messages. These are:
* CANbus_Send, which preserves closely its old functionality for backwards compatibility.
* CANbus_BlockAndSend, which puts the calling thread to sleep until the message can be sent.

If the first of the above messages is called, the caller is expected
to check for a proper transmission. If a guarenteed transmission is
required, the second function should be called.

To receive messages, there are likewise two functions: one nonblocking and
one blocking (CANbus_Receive & CANbus_WaitToReceive). Use the first one
only if you do not want to block and do not plan to poll.

Notes
=====
No testing has been done on these yet, and there has been no work on the
simulator portions.