### PR TITLE
RTOS header commments

### DIFF
--- a/Apps/Inc/Amps.h
+++ b/Apps/Inc/Amps.h
@@ -22,7 +22,7 @@ ErrorStatus Amps_UpdateMeasurements(void);
 
 /** Amps_CheckStatus
  * Checks if pack does not have a short circuit
- * @param isCharging is 1 if the battery pack is charging and 0 if it is not charging
+ * @param isCharging is true if the battery pack is charging and false if it is not charging
  * @return SAFE or DANGER
  */
 SafetyStatus Amps_CheckStatus(bool isCharging);

--- a/Apps/Inc/Amps.h
+++ b/Apps/Inc/Amps.h
@@ -1,11 +1,10 @@
 /* Copyright (c) 2020 UT Longhorn Racing Solar */
 /** Amps.h
- * File that holds all electrical current related information of BeVolt's
- * battery pack.
+ * File that holds all electrical current related information of BeVolt's battery pack.
  */
 
-#ifndef AMPS_H__
-#define AMPS_H__
+#ifndef AMPS_H
+#define AMPS_H
 
 #include "common.h"
 #include "config.h"
@@ -23,9 +22,10 @@ ErrorStatus Amps_UpdateMeasurements(void);
 
 /** Amps_CheckStatus
  * Checks if pack does not have a short circuit
+ * @param isCharging is 1 if the battery pack is charging and 0 if it is not charging
  * @return SAFE or DANGER
  */
-SafetyStatus Amps_CheckStatus(bool override);
+SafetyStatus Amps_CheckStatus(bool isCharging);
 
 /** Amps_IsCharging
  * Determines if the the battery pack is being charged or discharged depending on

--- a/Apps/Inc/CLI.h
+++ b/Apps/Inc/CLI.h
@@ -1,11 +1,10 @@
 /* Copyright (c) 2020 UT Longhorn Racing Solar */
 /* CLI.c
- * Command Line Interface file to 
- * define and route commands
+ * Command Line Interface file to define and route commands
  */
 
-#ifndef CLI_H__
-#define CLI_H__
+#ifndef CLI_H
+#define CLI_H
 
 #include "common.h"
 #include "config.h"
@@ -13,7 +12,7 @@
 #include "Voltage.h"
 
 // String hash values
-#define CLI_HELP_HASH						0x348B9F
+#define CLI_HELP_HASH			0x348B9F
 #define CLI_MENU_HASH           0x36D901
 #define CLI_VOLTAGE_HASH        0x1CF03ACC
 #define CLI_CURRENT_HASH        0x6FC625E
@@ -52,7 +51,7 @@
 #define CLI_ERROR_HASH          0x67AA6C8
 
 #define CLI_FAULT_HASH          0x69581E2
-#define CLI_RUN_HASH		    		0x1AB8B
+#define CLI_RUN_HASH		    0x1AB8B
 #define CLI_UVOLT_HASH          0x6956DF6
 #define CLI_OVOLT_HASH          0x6956DF0
 #define CLI_OTEMP_HASH          0x65D5E83
@@ -62,8 +61,8 @@
 
 #define CLI_OPENWIRE_HASH       0x8AF9D08 
 
-#define CLI_TRIP_HASH   				0x3481FB
-#define CLI_CLEAR_HASH					0x674180D
+#define CLI_TRIP_HASH   		0x3481FB
+#define CLI_CLEAR_HASH			0x674180D
 
 #define CLI_SHUTDOWN_HASH       0xE7D4586
 #define CLI_PARTYTIME_HASH      0x391FEB33
@@ -104,51 +103,43 @@ void CLI_Startup(void);
 void CLI_Help(void);
 
 /** CLI_Voltage
- * Checks and displays the desired
- * voltage parameter(s)
+ * Checks and displays the desired voltage parameter(s)
  * @param hashTokens is the array of hashed tokens
  */
 void CLI_Voltage(int* hashTokens);
 
 /** CLI_Current
- * Checks and displays the desired
- * current parameter(s)
+ * Checks and displays the desired current parameter(s)
  * @param hashTokens is the array of hashed tokens
  */
 void CLI_Current(int* hashTokens);
 
 /** CLI_Temperature
- * Checks and displays the desired
- * temperature parameter(s)
+ * Checks and displays the desired temperature parameter(s)
  * @param hashTokens is the array of hashed tokens
  */
 void CLI_Temperature(int* hashTokens);
 
 /** CLI_LTC6811
- * Prints register information
- * All registers are of the same type
- * Prints each register's respective three registers
- * (tx_data, rx_date, and rx_pec_match)
+ * Prints register information. All registers are of the same type
+ * Prints each register's respective three registers: tx_data, rx_date, and rx_pec_match
  */
 void CLI_LTC6811(void);
 
 /** CLI_Contactor
- * Interacts with contactor status by
- * printing the status of the contactor
+ * Interacts with contactor status by printing the status of the contactor
  * @param hashTokens is the array of hashed tokens
  */
 void CLI_Contactor(int* hashTokens);
 
 /** CLI_Charge
- * Checks and displays the desired
- * state of charge parameter(s)
+ * Checks and displays the desired state of charge parameter(s)
  * @param hashTokens is the array of hashed tokens
  */
 void CLI_Charge(int* hashTokens);
 
 /** setLED
- * Helper function for CLI_LED
- * that sets a given LED to a state
+ * Helper function for CLI_LED that sets a given LED to a state
  * @param led is the LED to toggle
  * @param state is the 'on' of 'off' state
  * 				represented by a 1/0 or hashes
@@ -156,17 +147,13 @@ void CLI_Charge(int* hashTokens);
 void setLED(Light input, int state);
 
 /** CLI_LED
- * Interacts with the LEDs by 
- * checking error light status
- * running a full LED test
- * and turning a specific LED on/off
+ * Interacts with the LEDs by checking error light status, running a full LED test, and turning a specific LED on/off
  * @param hashTokens is the array of hashed tokens
  */
 void CLI_LED(int* hashTokens);
 
 /** CLI_CAN
- * Interacts with CAN by
- * reading and writing to bus
+ * Interacts with CAN by reading and writing to bus
  * @param hashTokens is the array of hashed tokens
  */
 void CLI_CAN(int* hashTokens);
@@ -183,8 +170,7 @@ void CLI_Display(void);
 void CLI_Watchdog(int* hashTokens);
 
 /** CLI_EEPROM
- * Interacts with EEPROM
- * by reading and writing to the EEPROM
+ * Interacts with EEPROM by reading and writing to the EEPROM
  * @param hashTokens is the array of hashed tokens
  */
 void CLI_EEPROM(int* hashTokens);
@@ -201,14 +187,12 @@ void CLI_ADC(void);
 void CLI_Critical(void);
 
 /** CLI_All
- * Displays all information about BPS modules
- * (voltage, current, temperature, charge, contactor)
+ * Displays all information about BPS modules: voltage, current, temperature, charge, contactor
  */
 void CLI_All(void);
 
 /** CLI_Handler
- * Routes the command given to the proper
- * measurement method to check the desired values
+ * Routes the command given to the proper measurement method to check the desired values
  * @param input is a command string
  */
 void CLI_Handler(char* input);

--- a/Apps/Inc/Charge.h
+++ b/Apps/Inc/Charge.h
@@ -26,7 +26,7 @@ void Charge_Calculate(int32_t milliamps);
  * Calibrates the Charge. Whenever the BPS trips, the Charge should recalibrate. If an undervoltage
  * fault occurs, the Charge calibrates to 0% and whenever there is an overvoltage, the Charge calibrates
  * to 100%.
- * @param faultType of voltage. 0 if undervoltage, 1 if overvoltage
+ * @param faultType 0 if undervoltage, 1 if overvoltage
  */
 void Charge_Calibrate(int8_t faultType);
 

--- a/Apps/Inc/Charge.h
+++ b/Apps/Inc/Charge.h
@@ -12,14 +12,13 @@
 #include "EEPROM.h"
 
 /** Charge_Init
- * Initializes necessary timer and values to begin state of charge
- * calculation algorithm.
+ * Initializes necessary timer and values to begin state of charge calculation algorithm.
  */
 void Charge_Init(void);
 
 /** Charge_Calculate
  * Calculates new Charge depending on the current reading
- * @param current reading from hall effect sensors. Fixed point of 0.0001 (1.500 Amps = 15000)
+ * @param milliamps current reading from hall effect sensors. Fixed point of 0.0001 (1.500 Amps = 15000)
  */
 void Charge_Calculate(int32_t milliamps);
 
@@ -27,7 +26,7 @@ void Charge_Calculate(int32_t milliamps);
  * Calibrates the Charge. Whenever the BPS trips, the Charge should recalibrate. If an undervoltage
  * fault occurs, the Charge calibrates to 0% and whenever there is an overvoltage, the Charge calibrates
  * to 100%.
- * @param voltage fault type. 0 if under voltage, 1 if over voltage
+ * @param faultType of voltage. 0 if undervoltage, 1 if overvoltage
  */
 void Charge_Calibrate(int8_t faultType);
 

--- a/Apps/Inc/Tasks.h
+++ b/Apps/Inc/Tasks.h
@@ -1,6 +1,6 @@
 /* Copyright (c) 2020 UT Longhorn Racing Solar */
-#ifndef __TASKS_H
-#define __TASKS_H
+#ifndef TASKS_H
+#define TASKS_H
 
 #include "os.h"
 #include <stdint.h>
@@ -11,9 +11,9 @@
 #define TASK_PETWDOG_PRIO                   3
 #define TASK_VOLT_TEMP_MONITOR_PRIO         4
 #define TASK_AMPERES_MONITOR_PRIO           5
-#define TASK_BATTERY_BALANCE_PRIO           6 //BATTERY
-#define TASK_CANBUS_CONSUMER_PRIO           7 //CANBUS
-#define TASK_LOG_INFO_PRIO                  8 //LOGINFO
+#define TASK_BATTERY_BALANCE_PRIO           6
+#define TASK_CANBUS_CONSUMER_PRIO           7
+#define TASK_LOG_INFO_PRIO                  8 
 #define TASK_CLI_PRIO                       9  
 #define TASK_IDLE_PRIO                      10
 
@@ -77,7 +77,7 @@ void Task_Init(void *p_arg);
 void assertOSError(OS_ERR err);
 
 /*
- * @brief   TCBs
+ * Thread Control Blocks that contain information about each thread
  */
 extern OS_TCB FaultState_TCB;
 extern OS_TCB CriticalState_TCB;
@@ -92,7 +92,7 @@ extern OS_TCB BLE_TCB;
 extern OS_TCB Idle_TCB;
 extern OS_TCB Init_TCB;
 /**
- * @brief   Stacks
+ * Stacks for each thread
  */
 extern CPU_STK FaultState_Stk[TASK_FAULT_STATE_STACK_SIZE];
 extern CPU_STK CriticalState_Stk[TASK_CANBUS_CONSUMER_STACK_SIZE];
@@ -108,14 +108,16 @@ extern CPU_STK Idle_Stk[TASK_IDLE_STACK_SIZE];
 extern CPU_STK Init_Stk[TASK_INIT_STACK_SIZE];
 
 /**	
- * @brief   Queue for pushing and popping CAN Messages	
+ * Queue for pushing and popping CAN Messages	
  */	
 extern OS_Q CANBus_MsgQ;
 
+/**
+ *  Semaphores, Mutexes, & Bitmaps that are used by multiple threads
+ */
 extern OS_SEM SafetyCheck_Sem4;
 extern OS_SEM Fault_Sem4;
 extern OS_MUTEX WDog_Mutex;
 extern uint32_t WDog_BitMap;
-extern OS_Q CANBus_MsgQ;
 
 #endif

--- a/Apps/Inc/Temperature.h
+++ b/Apps/Inc/Temperature.h
@@ -1,14 +1,13 @@
 /* Copyright (c) 2020 UT Longhorn Racing Solar */
 
 /** Temperature.h
- * Temperature file that holds all Temperature related information of BeVolt's
- * battery pack.
+ * Temperature file that holds all Temperature related information of BeVolt's battery pack.
  */
 
 // NOTE: All units are in Celsius
 
-#ifndef TEMPERATURE_H__
-#define TEMPERATURE_H__
+#ifndef TEMPERATURE_H
+#define TEMPERATURE_H
 
 #include "common.h"
 #include "config.h"
@@ -25,6 +24,7 @@
 /** Temperature_Init
  * Initializes device drivers including SPI inside LTC6811_init and LTC6811 for Temperature Monitoring
  * @param boards LTC6811 data structure that contains the values of each register
+ * @return SUCCESS or ERROR
  */
 ErrorStatus Temperature_Init(cell_asic *boards);
 
@@ -34,7 +34,8 @@ ErrorStatus Temperature_Init(cell_asic *boards);
  * @precondition tempChannel should be < MAX_TEMP_SENSORS_PER_MINION_BOARD
  * @param channel number (0-indexed based)
  * @return SUCCESS or ERROR
- * @note we clear the otherMux every time a channel is switched even on the same mux; Maybe change depending on speed/optimization
+ * @note we clear the otherMux every time a channel is switched even on the same mux
+ * Maybe change depending on speed/optimization
  */
 ErrorStatus Temperature_ChannelConfig(uint8_t tempChannel);
 
@@ -70,7 +71,8 @@ SafetyStatus Temperature_CheckStatus(uint8_t isCharging);
  * Lithium Ion Cells have two separate max temperature limits. There is a limit
  * when the battery is charging and another limit when the battery is discharging.
  * We need to account for these two limits by setting which limit should be used.
- * ChargingState is used for GetModulesInDanger when we can't use the current module to check if charging or discharging
+ * ChargingState is used for GetModulesInDanger when we can't use the current module 
+ * to check if charging or discharging
  * @param 1 if pack is charging, 0 if discharging
  */
 void Temperature_SetChargeState(uint8_t isCharging);
@@ -92,8 +94,8 @@ uint8_t *Temperature_GetModulesInDanger(void);
 int32_t Temperature_GetSingleTempSensor(uint8_t board, uint8_t sensorIdx);
 
 /** Temperature_GetModuleTemperature
- * Gets the avg temperature of a certain battery module in the battery pack. Since there
- * are 2 sensors per module, the return value is the average
+ * Gets the avg temperature of a certain battery module in the battery pack. 
+ * Since there are 2 sensors per module, the return value is the average
  * @precondition: moduleIdx must be < NUM_BATTERY_MODULE
  * @param index of module (0-indexed based)
  * @return temperature of the battery module at specified index
@@ -108,7 +110,7 @@ int32_t Temperature_GetTotalPackAvgTemperature(void);
 
 /** Temperature_SampleADC
  * Starts ADC conversion on GPIO1 on LTC6811's auxiliary registers on all boards
- * @param sets the sampling rate
+ * @param ADCMode sets the sampling rate
  * @return SUCCESS or ERROR
  */
 ErrorStatus Temperature_SampleADC(uint8_t ADCMode);

--- a/Apps/Inc/Voltage.h
+++ b/Apps/Inc/Voltage.h
@@ -1,12 +1,11 @@
 /* Copyright (c) 2020 UT Longhorn Racing Solar */
 
 /** Voltage.h
- * Voltage file that holds all voltage related information of BeVolt's
- * battery pack.
+ * Voltage file that holds all voltage related information of BeVolt's battery pack.
  */
 
-#ifndef VOLTAGE_H__
-#define VOLTAGE_H__
+#ifndef VOLTAGE_H
+#define VOLTAGE_H
 
 #include <stdint.h>
 #include "config.h"
@@ -41,7 +40,7 @@ ErrorStatus Voltage_UpdateMeasurements(void);
 SafetyStatus Voltage_CheckStatus(void);
 
 /** Voltage_GetModulesInDanger
- * Finds all battery modules that in danger and stores them into a list.
+ * Finds all battery modules in danger and stores them into a list.
  * Each battery module corresponds to and index of the array. If the element in the
  * array is 1, then it means that module in the index is in danger.
  * @return struct that has safety status for all wires and modules in the system

--- a/Apps/Inc/common.h
+++ b/Apps/Inc/common.h
@@ -1,6 +1,6 @@
 /* Copyright (c) 2020 UT Longhorn Racing Solar */
-#ifndef __COMMON_H
-#define __COMMON_H
+#ifndef COMMON_H
+#define COMMON_H
 
 #include <ctype.h>
 #include <stdint.h>
@@ -9,7 +9,5 @@
 #include <string.h>
 #include <stdlib.h>
 #include <math.h>
-
-extern bool AdminOverride;
 
 #endif

--- a/BSP/Inc/BSP_ADC.h
+++ b/BSP/Inc/BSP_ADC.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2020 UT Longhorn Racing Solar */
 
-#ifndef __BSP_ADC_H
-#define __BSP_ADC_H
+#ifndef BSP_ADC_H
+#define BSP_ADC_H
 
 #include "common.h"
 

--- a/BSP/Inc/BSP_CAN.h
+++ b/BSP/Inc/BSP_CAN.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2020 UT Longhorn Racing Solar */
 
-#ifndef __BSP_CAN_H
-#define __BSP_CAN_H
+#ifndef BSP_CAN_H
+#define BSP_CAN_H
 
 #include "common.h"
 #include "config.h"

--- a/BSP/Inc/BSP_Contactor.h
+++ b/BSP/Inc/BSP_Contactor.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2020 UT Longhorn Racing Solar */
 
-#ifndef __BSP_CONTACTOR_H
-#define __BSP_CONTACTOR_H
+#ifndef BSP_CONTACTOR_H
+#define BSP_CONTACTOR_H
 
 #include "common.h"
 
@@ -13,8 +13,8 @@
 /**
  * @brief   Initializes the GPIO pins that interfaces with the Contactor.
  *          Two GPIO pins are initialized. One as an output and one as an input.
- *          The output pin controls the state and the input pin views what state the contactor is through the
- *          Aux pins.
+ *          The output pin controls the state and the input pin views what state the 
+ *          contactor is through the Aux pins.
  * @param   None
  * @return  None
  */
@@ -23,8 +23,7 @@ void BSP_Contactor_Init(void);
 /**
  * @brief   Closes the Contactor switch i.e. turns on the whole electrical system.
  * @note    May be good in the future to make this return something if the contactor could not successfully close.
- * @param   None
- * @return  None
+
  */
 void BSP_Contactor_On(void);
 

--- a/BSP/Inc/BSP_Fans.h
+++ b/BSP/Inc/BSP_Fans.h
@@ -1,11 +1,10 @@
 /* Copyright (c) 2020 UT Longhorn Racing Solar */
 
 /* Fans.h
-Controls speed of fans which cool down the battery pack.
-Uses Pins PC6,7 and PB14,15
+Controls speed of fans which cool down the battery pack. Uses Pins PC6, 7 and PB14, 15
 */
-#ifndef __BSP_FANS_H
-#define __BSP_FANS_H
+#ifndef BSP_FANS_H
+#define BSP_FANS_H
 
 #include "common.h"
 #include "config.h"
@@ -23,7 +22,7 @@ void BSP_Fans_Init(void);
 /**
  * @brief   Sets fan duty cycle
  * @param   dutyCycle: int for duty cycle amount in range 0-8
- *          fan: fan number whose speed should be changed
+ * @param   fan: fan number whose speed should be changed
  * @return  ErrorStatus
  */
 ErrorStatus BSP_Fans_Set(uint8_t fan, uint32_t speed);

--- a/BSP/Inc/BSP_I2C.h
+++ b/BSP/Inc/BSP_I2C.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2020 UT Longhorn Racing Solar */
 
-#ifndef __BSP_I2C_H
-#define __BSP_I2C_H
+#ifndef BSP_I2C_H
+#define BSP_I2C_H
 
 #include "common.h"
 #include "os.h"

--- a/BSP/Inc/BSP_Lights.h
+++ b/BSP/Inc/BSP_Lights.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2020 UT Longhorn Racing Solar */
 
-#ifndef __BSP_LIGHTS_H
-#define __BSP_LIGHTS_H
+#ifndef BSP_LIGHTS_H
+#define BSP_LIGHTS_H
 
 #include "common.h"
 #include "config.h"

--- a/BSP/Inc/BSP_OS.h
+++ b/BSP/Inc/BSP_OS.h
@@ -1,6 +1,6 @@
 /* Copyright (c) 2020 UT Longhorn Racing Solar */
-#ifndef __BSP_OS_H
-#define __BSP_OS_H
+#ifndef BSP_OS_H
+#define BSP_OS_H
 
 typedef struct {
     void (*pend)(void);

--- a/BSP/Inc/BSP_PLL.h
+++ b/BSP/Inc/BSP_PLL.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2020 UT Longhorn Racing Solar */
 
-#ifndef __BSP_PLL_H
-#define __BSP_PLL_H
+#ifndef BSP_PLL_H
+#define BSP_PLL_H
 
 #include "common.h"
 

--- a/BSP/Inc/BSP_SPI.h
+++ b/BSP/Inc/BSP_SPI.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2020 UT Longhorn Racing Solar */
 
-#ifndef __BSP_SPI_H
-#define __BSP_SPI_H
+#ifndef BSP_SPI_H
+#define BSP_SPI_H
 
 #include "common.h"
 #include "os.h"
@@ -39,10 +39,9 @@ void BSP_SPI_Init(spi_port_t port, bsp_os_t *spi_os);
 void BSP_SPI_Write(spi_port_t port, uint8_t *txBuf, uint32_t txLen);
 
 /**
- * @brief   Gets the data from SPI. With the way the LTC6811 communication works,
- *          the LTC6811 will not be expecting anything from the uC.
- *          The SPI protocol requires the uC to transmit data in order to receive
- *          anything so the uC will send junk data.
+ * @brief   Gets the data from SPI. With the way the LTC6811 communication works, the LTC6811 will 
+ *          not be expecting anything from the uC. The SPI protocol requires the uC to transmit 
+ *          data in order to receive anything so the uC will send junk data.
  * @note    Blocking statement
  * @param   port    the SPI port to read from
  * @param   rxBuf   data array to store the data that is received.
@@ -52,10 +51,9 @@ void BSP_SPI_Write(spi_port_t port, uint8_t *txBuf, uint32_t txLen);
 void BSP_SPI_Read(spi_port_t port, uint8_t *rxBuf, uint32_t rxLen);
 
 /**
- * @brief   Sets the state of the chip select output pin.
- *          Set the state to low/0 to notify the LTC6811 that the data sent on the
- *          SPI lines are for it. Set the state to high/1 to make the LTC6811
- *          go to standby.
+ * @brief   Sets the state of the chip select output pin. Set the state to low/0 to notify the 
+ *          LTC6811 that the data sent on the SPI lines are for it. Set the state to high/1 to 
+ *          make the LTC6811 go to standby.
  * @param   port    the SPI port to select/deselct on
  * @param   state   0 for select, 1 to deselect
  * @return  None

--- a/BSP/Inc/BSP_Strobelight.h
+++ b/BSP/Inc/BSP_Strobelight.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2020 UT Longhorn Racing Solar */
 
-#ifndef __BSP_STROBELIGHT_H
-#define __BSP_STROBELIGHT_H
+#ifndef BSP_STROBELIGHT_H
+#define BSP_STROBELIGHT_H
 
 #include "common.h"
 #include "config.h"

--- a/BSP/Inc/BSP_Timer.h
+++ b/BSP/Inc/BSP_Timer.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2020 UT Longhorn Racing Solar */
 
-#ifndef __BSP_TIMER_H
-#define __BSP_TIMER_H
+#ifndef BSP_TIMER_H
+#define BSP_TIMER_H
 
 #include "common.h"
 

--- a/BSP/Inc/BSP_UART.h
+++ b/BSP/Inc/BSP_UART.h
@@ -1,11 +1,12 @@
 /* Copyright (c) 2020 UT Longhorn Racing Solar */
 
-#ifndef __BSP_UART_H
-#define __BSP_UART_H
+#ifndef BSP_UART_H
+#define BSP_UART_H
 
 #include "common.h"
 #include "os.h"
 
+//enum to describe what UART port you are trying to access
 typedef enum {UART_USB, UART_BLE} UART_Port;
 
 /**
@@ -15,16 +16,15 @@ void BSP_UART_Init(void);
 
 /**
  * @brief   Gets one line of ASCII text that was received.
- * @pre     str should be at least 128bytes long.
- * @param   str : pointer to string to store the string. This buffer should be initialized
- *                  before hand.
+ * @pre     str should be at least 128 bytes long.
+ * @param   str : pointer to string to store the string. This buffer should be initialized before hand.
  * @param   usart : which usart to read from (USB or BLE)     
  * @return  number of bytes that was read
  */
 uint32_t BSP_UART_ReadLine(char *str, UART_Port usart);
 
 /**
- * @brief   Transmits data to through UART line
+ * @brief   Transmits data through UART line
  * @param   str : pointer to buffer with data to send.
  * @param   len : size of buffer
  * @param   usart : which usart to read from (USB or BLE)

--- a/BSP/Inc/BSP_WDTimer.h
+++ b/BSP/Inc/BSP_WDTimer.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2020 UT Longhorn Racing Solar */
 
-#ifndef __BSP_WDTIMER_H
-#define __BSP_WDTIMER_H
+#ifndef BSP_WDTIMER_H
+#define BSP_WDTIMER_H
 
 #include "common.h"
 

--- a/Drivers/Inc/AS8510.h
+++ b/Drivers/Inc/AS8510.h
@@ -1,11 +1,12 @@
-#ifndef AS8510_H__
-#define AS8510_H__
+#ifndef AS8510_H
+#define AS8510_H
+
+// Driver for AS8510 current sensor.
 
 #include "common.h"
 #include "config.h"
 
-/* Initialize communication with the AS8510
- * to begin measurement of electrical current.
+/* Initialize communication with the AS8510 to begin measurement of electrical current.
  */
 void AS8510_Init();
 
@@ -32,6 +33,7 @@ ErrorStatus AS8510_ReadFromAddr(uint8_t addr, uint8_t *data, uint8_t len);
 uint8_t AS8510_ReadRegister(uint8_t addr);
 
 /* Gets the current from the AS8510
+ * @return current in milliamps
  */
 int16_t AS8510_GetCurrent();
 

--- a/Drivers/Inc/BatteryBalancing.h
+++ b/Drivers/Inc/BatteryBalancing.h
@@ -9,7 +9,8 @@
 #include "Voltage.h"
 
 /**
- * @brief   Loops through all 31 modules, sets discharge bits for any module if its voltage is too high, and clears discharge bits for any modules with voltages that are too low
+ * @brief   Loops through all 31 modules, sets discharge bits for any module if its voltage is 
+ *          too high, and clears discharge bits for any modules with voltages that are too low
  * @param   Minions array of the ICs that the modules are connected to
  * @return  None
  */

--- a/Drivers/Inc/CANbus.h
+++ b/Drivers/Inc/CANbus.h
@@ -1,11 +1,12 @@
 /* Copyright (c) 2020 UT Longhorn Racing Solar */
 
-#ifndef __CANBUS_H
-#define __CANBUS_H
+#ifndef CANBUS_H
+#define CANBUS_H
 
 #include "common.h"
 #include "config.h"
 
+//Enum for ID's of all messages that can be sent across CAN bus
 typedef enum {
     TRIP = 0x02,
     ALL_CLEAR = 0x101,
@@ -19,6 +20,7 @@ typedef enum {
     MOTOR_DISABLE = 0x10A
 } CANId_t;
 
+//Union of data that can be sent across CAN bus. Only one field must be filled out
 typedef union {
 	uint8_t b;
 	uint16_t h;
@@ -49,10 +51,8 @@ typedef struct {
 void CANbus_Init(void);
 
 /**
- * @brief   Transmits data onto the CANbus.
- *          This is non-blocking and will fail with an error if
- * 			the CAN mailboxes are fully occupied. Be sure to
- * 			check the return code or call CANbus_BlockAndSend.
+ * @brief   Transmits data onto the CANbus. This is non-blocking and will fail with an error if
+ * 			the CAN mailboxes are fully occupied. Be sure to check the return code or call CANbus_BlockAndSend.
  * @param   id : CAN id of the message
  * @param   payload : the data that will be sent.
  * @return  ERROR if data wasn't sent, otherwise it was sent.

--- a/Drivers/Inc/EEPROM.h
+++ b/Drivers/Inc/EEPROM.h
@@ -7,8 +7,8 @@
  * The EEPROM is 128Kbits (16k x 8 bits) and uses I2C
  */
 
-#ifndef EEPROM_H__
-#define EEPROM_H__
+#ifndef EEPROM_H
+#define EEPROM_H
 
 #include <stdint.h>
 
@@ -31,8 +31,8 @@
 #define EEPROM_VOLT_PTR_LOC	    0x1004
 #define EEPROM_CURRENT_PTR_LOC  0x1006
 #define EEPROM_WATCHDOG_PTR_LOC 0x1008
-#define EEPROM_CAN_PTR_LOC		  0x100A
-#define EEPROM_SOC_PTR_LOC			0x100C
+#define EEPROM_CAN_PTR_LOC		0x100A
+#define EEPROM_SOC_PTR_LOC		0x100C
 
 /** EEPROM_Init
  * Initializes I2C to communicate with EEPROM (M24128)
@@ -40,32 +40,29 @@
 void EEPROM_Init(void);
 
 /** EEPROM_Load
- * Loads the pointers from memory. Should be done after
- * initialization and before reading or writing to the
- * EEPROM.
+ * Loads the pointers from memory. Should be done after initialization and before reading or 
+ * writing to the EEPROM.
  */
 void EEPROM_Load(void);
 
 /** EEPROM_Reset
- * Resets the EEPROM. This will clear all data that has
- * been logged so far.
- *
- * This is required for clearing data and setting up new
- * EEPROMs. This cmd really should be reserved for specialized
- * set-up programs and the cli.
+ * Resets the EEPROM. This will clear all data that has been logged so far. This is required for 
+ * clearing data and setting up new EEPROMs. This CMD really should be reserved for specialized
+ * set-up programs and the CLI.
  */
 void EEPROM_Reset(void);
 
 /** EEPROM_LogData
- * This logs the given data at an appropriate spot in memory.
- * This does not log an actual error, but allows more specific
- * information about failed modules to be logged.
+ * This logs the given data at an appropriate spot in memory. This does not log an actual error, 
+ * but allows more specific information about failed modules to be logged.
+ * @param logType is the type of fault that occured (fault code)
+ * @param data is the data corresponding to the logType, 0 if nothing to be logged
  */
 void EEPROM_LogData(uint8_t logType, uint8_t data);
 
 /** EEPROM_Save
  * Save some information to the EEPROM
- * logType is type of fault (fault code)
+ * @param logType is type of fault (fault code)
  */
 void EEPROM_LogError(uint8_t logType);
 
@@ -82,36 +79,37 @@ void EEPROM_Tester(void);
 
 /** EEPROM_WriteMultipleBytes
  * Saves data to the EEPROM
- * @param unsigned 16-bit address
- * @param unsigned 8-bit data
+ * @param address to write data to
+ * @param bytes number of bytes to send
+ * @param buffer pointer to buffer that contains data
  */
 void EEPROM_WriteMultipleBytes(uint16_t address, uint32_t bytes, uint8_t* buffer);
 
 /** EEPROM_Write
  * Saves data to the EEPROM at the specified address
- * @param unsigned 16-bit address
- * @param unsigned 8-bit data
+ * @param unsigned to write data to
+ * @param unsigned data to send
  */
 void EEPROM_WriteByte(uint16_t address, uint8_t data);
 
 /** EEPROM_ReadMultipleBytes
  * Gets multiple bytes of data sequentially from EEPROM beginning at specified address
- * @param unsigned 16-bit address
- * @param number of bytes to read
- * @return unsigned 8-bit list of data
+ * @param address to read data from
+ * @param bytes number of bytes to read
+ * @param buffer pointer to buffer to store data in
  */
 void EEPROM_ReadMultipleBytes(uint16_t address, uint32_t bytes, uint8_t* buffer);
 
 /** EEPROM_ReadByte
  * Gets single bytes of data sequentially from EEPROM beginning at specified address
- * @param unsigned 16-bit address
- * @return unsigned 8-bit data
+ * @param address to read data from
+ * @return unsigned 8-bit data that was read
  */
 uint8_t EEPROM_ReadByte(uint16_t address);
 
 /** DelayMS
  * Delays for specified number of milliseconds (not accurate)
- * @param input is number of milliseconds to delay
+ * @param ms is number of milliseconds to delay
  */
 void DelayMs(uint32_t ms);
 


### PR DESCRIPTION
Made all header file defines the same format. Added @param and @return wherever they were missing. Added extra information where needed. Fixed incorrect information that was from the old version of BPS. Fixed tabs issues in #define.