### PR TITLE
Verified Watchdog Task

### DIFF
--- a/Apps/Src/Task_FaultState.c
+++ b/Apps/Src/Task_FaultState.c
@@ -21,14 +21,17 @@
  */
 void EnterFaultState() {
     // Turn Contactor Off
+    BSP_Contactor_Init();
     BSP_Contactor_Off();
     //Set Fans to full speed
+    BSP_Fans_Init();
     BSP_Fans_Set(1, 8);
     BSP_Fans_Set(2, 8);
     BSP_Fans_Set(3, 8);
     BSP_Fans_Set(4, 8);
     // Turn Strobe Light On
     // Turn LEDs On and logs Error into EEPROM
+    BSP_Lights_Init();
     BSP_Light_Off(RUN); //turn off run light
     BSP_Light_On(FAULT);
     if (BSP_WDTimer_DidSystemReset()) Fault_BitMap = Fault_WDOG;

--- a/Apps/Src/Task_PetWDog.c
+++ b/Apps/Src/Task_PetWDog.c
@@ -8,6 +8,10 @@ void Task_PetWDog(void *p_arg) {
 
     OS_ERR err;
 
+    BSP_WDTimer_Init();
+    BSP_WDTimer_Start();
+    
+
     while (1){
         //take WDog Mutex
         OSMutexPend(&WDog_Mutex, 0, OS_OPT_PEND_BLOCKING, NULL, &err);
@@ -18,7 +22,8 @@ void Task_PetWDog(void *p_arg) {
         // The three least significant bits of WDog_BitMap will be set if:
         // temp, voltage, current tasks are set --> value = 7
         if (WDog_BitMap == 7) {     
-             BSP_WDTimer_Reset();
+            BSP_WDTimer_Reset();
+            WDog_BitMap = 0;
         }
    
         //release WDog Mutex

--- a/Apps/Src/Task_PetWDog.c
+++ b/Apps/Src/Task_PetWDog.c
@@ -30,7 +30,7 @@ void Task_PetWDog(void *p_arg) {
         OSMutexPost(&WDog_Mutex, OS_OPT_POST_NONE, &err);
         assertOSError(err);
 
-        OSTimeDly(40, OS_OPT_TIME_DLY, &err);
+        OSTimeDly(20, OS_OPT_TIME_DLY, &err);
         assertOSError(err);
     }
 }

--- a/BSP/STM32F413/Src/BSP_WDTimer.c
+++ b/BSP/STM32F413/Src/BSP_WDTimer.c
@@ -10,10 +10,10 @@
  */
 void BSP_WDTimer_Init(void) {
     // Independent Watchdog Init
-    // IWDG has a timeout value of 4.096 seconds.
+    // IWDG has a timeout value of 4.096 / 8 seconds (about 500ms).
 	IWDG_WriteAccessCmd(IWDG_WriteAccess_Enable);       // Enable access to the IWDG_PR and IWDG_RLR registers
 	IWDG_SetPrescaler(IWDG_Prescaler_32);               // Prescaler divider feeding the counter clock
-	IWDG_SetReload(IWDG_RLR_RL);                        // Reload value set to 0xFFF
+	IWDG_SetReload(IWDG_RLR_RL / 8);                    // Reload value set to 0xFFF / 8
 }
 
 /**

--- a/Tests/Test_WD_Task.c
+++ b/Tests/Test_WD_Task.c
@@ -23,7 +23,7 @@ void Task2(void *p_arg){
    
     while(1) {
         BSP_Light_Toggle(EXTRA);
-        OSTimeDly(10, OS_OPT_TIME_DLY, &err);
+        OSTimeDly(25, OS_OPT_TIME_DLY, &err);
         // Comment out the following lines to test watchdog timeout
         OSMutexPend(&WDog_Mutex, 0, OS_OPT_PEND_BLOCKING, NULL, &err);
         WDog_BitMap = 7;

--- a/Tests/Test_WD_Task.c
+++ b/Tests/Test_WD_Task.c
@@ -1,0 +1,110 @@
+/* Copyright (c) 2021 UT Longhorn Racing Solar */
+
+#include "common.h"
+#include "config.h"
+#include "os.h"
+#include "Tasks.h"
+#include "stm32f4xx.h"
+#include "BSP_Lights.h"
+#include "BSP_PLL.h"
+#include "BSP_WDTimer.h"
+
+OS_TCB Task1_TCB;
+CPU_STK Task1_Stk[256];
+OS_TCB Task2_TCB;
+CPU_STK Task2_Stk[256];
+
+void EnterFaultState();
+
+void Task2(void *p_arg){
+    OS_ERR err;
+    
+    BSP_Lights_Init();
+   
+    while(1) {
+        BSP_Light_Toggle(EXTRA);
+        OSTimeDly(10, OS_OPT_TIME_DLY, &err);
+        // Comment out the following lines to test watchdog timeout
+        OSMutexPend(&WDog_Mutex, 0, OS_OPT_PEND_BLOCKING, NULL, &err);
+        WDog_BitMap = 7;
+        OSMutexPost(&WDog_Mutex, OS_OPT_POST_NONE, &err);
+    }
+
+    exit(0);
+}
+
+void Task1(void *p_arg){
+    OS_ERR err;
+
+    OS_CPU_SysTickInit(SystemCoreClock / (CPU_INT32U) OSCfg_TickRate_Hz);
+
+    OSMutexCreate(&WDog_Mutex,
+                "Watchdog Mutex",
+                &err);
+    assertOSError(err);
+    
+    OSTaskCreate(&Task2_TCB,
+                "Task 2",
+                Task2,
+                (void *)0,
+                10,
+                Task2_Stk,
+                16,
+                256,
+                0,
+                0,
+                (void *)0,
+                OS_OPT_TASK_SAVE_FP | OS_OPT_TASK_STK_CHK,
+                &err);
+
+    OSTaskCreate(&PetWDog_TCB,				// TCB
+				"TASK_PETWDOG_PRIO",	// Task Name (String)
+				Task_PetWDog,				// Task function pointer
+				(void *)0,				// Task function args
+				TASK_PETWDOG_PRIO,			// Priority
+				PetWDog_Stk,				// Stack
+				WATERMARK_STACK_LIMIT,	// Watermark limit for debugging
+				TASK_PETWDOG_STACK_SIZE,		// Stack size
+				0,						// Queue size (not needed)
+				10,						// Time quanta (time slice) 10 ticks
+				(void *)0,				// Extension pointer (not needed)
+				OS_OPT_TASK_STK_CHK | OS_OPT_TASK_SAVE_FP,	// Options
+				&err);					// return err code
+
+    OSTaskDel(NULL, &err);
+}
+
+int main(void) {
+    OS_ERR err;
+    BSP_PLL_Init();
+    BSP_Lights_Init();
+    //BSP_WDTimer_Init();
+
+    if (BSP_WDTimer_DidSystemReset()) {
+		EnterFaultState();
+	}
+
+    __disable_irq();
+
+    OSInit(&err);
+    while(err != OS_ERR_NONE);
+
+    OSTaskCreate(&Task1_TCB,
+                "Task 1",
+                Task1,
+                (void *)0,
+                1,
+                Task1_Stk,
+                16,
+                256,
+                0,
+                0,
+                (void *)0,
+                OS_OPT_TASK_SAVE_FP | OS_OPT_TASK_STK_CHK,
+                &err);
+    while(err != OS_ERR_NONE);
+
+    __enable_irq();
+
+    OSStart(&err);
+}


### PR DESCRIPTION
The watchdog tasks resets the watchdog and the bitmap when the bitmap is set. The watchdog also resets the system and causes it to enter a fault state when it times out.