### PR TITLE
CAN bug fixes

### DIFF
--- a/Apps/Inc/CAN_Queue.h
+++ b/Apps/Inc/CAN_Queue.h
@@ -1,0 +1,17 @@
+/* Copyright (c) 2021 UT Longhorn Racing Solar */
+/** CAN_Queue.c
+ * Queue that holds all CAN messages that Task_CANBusConsumer needs to send.
+ */
+
+#ifndef CAN_QUEUE_H
+#define CAN_QUEUE_H
+
+#include "CANbus.h"
+
+void CAN_Queue_Init(void);
+
+void CAN_Queue_Post(CANMSG_t message);
+
+ErrorStatus CAN_Queue_Pend(CANMSG_t *message);
+
+#endif

--- a/Apps/Inc/CAN_Queue.h
+++ b/Apps/Inc/CAN_Queue.h
@@ -10,7 +10,7 @@
 
 void CAN_Queue_Init(void);
 
-void CAN_Queue_Post(CANMSG_t message);
+ErrorStatus CAN_Queue_Post(CANMSG_t message);
 
 ErrorStatus CAN_Queue_Pend(CANMSG_t *message);
 

--- a/Apps/Inc/Tasks.h
+++ b/Apps/Inc/Tasks.h
@@ -33,8 +33,6 @@
 #define TASK_IDLE_STACK_SIZE                DEFAULT_STACK_SIZE
 #define TASK_INIT_STACK_SIZE                DEFAULT_STACK_SIZE
 
-#define CANBUS_QUEUE_LENGTH 128
-
 /**
  * enum to keep track of which tasks correspond to each bit in WDog_BitMap
  */
@@ -107,11 +105,6 @@ extern CPU_STK CLI_Stk[TASK_CLI_STACK_SIZE];
 extern CPU_STK BLE_Stk[TASK_BLE_STACK_SIZE];
 extern CPU_STK Idle_Stk[TASK_IDLE_STACK_SIZE];
 extern CPU_STK Init_Stk[TASK_INIT_STACK_SIZE];
-
-/**	
- * Queue for pushing and popping CAN Messages	
- */	
-extern OS_Q CANBus_MsgQ;
 
 /**
  *  Semaphores, Mutexes, & Bitmaps that are used by multiple threads

--- a/Apps/Src/CAN_Queue.c
+++ b/Apps/Src/CAN_Queue.c
@@ -1,0 +1,63 @@
+/* Copyright (c) 2020 UT Longhorn Racing Solar */
+/** CAN_Queue.c
+ * Queue that holds all CAN messages that Task_CANBusConsumer needs to send.
+ */
+
+#include "CAN_Queue.h"
+#include "os.h"
+#include "CANbus.h"
+#include "Tasks.h"
+
+// fifo
+#define FIFO_TYPE CANMSG_t
+#define FIFO_SIZE 256
+#define FIFO_NAME CAN_fifo
+#include "fifo.h"
+
+static CAN_fifo_t canFifo;
+static OS_SEM canFifoSem;
+static OS_MUTEX canFifoMutex;
+
+void CAN_Queue_Init(void) {
+    OS_ERR err;
+    CPU_TS ticks;
+    OSMutexCreate(&canFifoMutex, "CAN queue mutex", &err);
+    assertOSError(err);
+    OSSemCreate(&canFifoSem,
+                "CAN queue semaphore",
+                0,
+                &err);
+    assertOSError(err);
+    OSMutexPend(&canFifoMutex, 0, OS_OPT_POST_NONE, &ticks, &err);
+    assertOSError(err);
+    CAN_fifo_renew(&canFifo);
+    OSMutexPost(&canFifoMutex, OS_OPT_POST_NONE, &err);
+    assertOSError(err);
+}
+
+void CAN_Queue_Post(CANMSG_t message) {
+    OS_ERR err;
+    CPU_TS ticks;
+    OSMutexPend(&canFifoMutex, 0, OS_OPT_POST_NONE, &ticks, &err);
+    assertOSError(err);
+    CAN_fifo_put(&canFifo, message);
+    OSMutexPost(&canFifoMutex, OS_OPT_POST_NONE, &err);
+    assertOSError(err);
+    OSSemPost(&canFifoSem, OS_OPT_POST_1, &err);
+    assertOSError(err);
+}
+
+ErrorStatus CAN_Queue_Pend(CANMSG_t *message) {
+    OS_ERR err;
+	CPU_TS ticks;
+    
+    OSSemPend(&canFifoSem, 0, OS_OPT_PEND_BLOCKING, &ticks, &err);
+    assertOSError(err);
+    OSMutexPend(&canFifoMutex, 0, OS_OPT_POST_NONE, &ticks, &err);
+    assertOSError(err);
+    bool result = CAN_fifo_get(&canFifo, message);
+    OSMutexPost(&canFifoMutex, OS_OPT_POST_NONE, &err);
+    assertOSError(err);
+    return result ? SUCCESS : ERROR;
+}
+

--- a/Apps/Src/Task_Amperes.c
+++ b/Apps/Src/Task_Amperes.c
@@ -5,6 +5,7 @@
 #include "AS8510.h"
 #include "os.h"
 #include "Tasks.h"
+#include "CAN_Queue.h"
 #include "BSP_SPI.h"
 #include "CANbus.h"
 
@@ -50,7 +51,7 @@ void Task_AmperesMonitor(void *p_arg) {
 		CanPayload.data = CanData;
 		CanMsg.id = CURRENT_DATA;
 		CanMsg.payload = CanPayload;
-		OSQPost(&CANBus_MsgQ, &CanMsg, 4, OS_OPT_POST_FIFO, &err); //Send data to Can
+        CAN_Queue_Post(CanMsg);         // send data to CAN
 
         //signal watchdog
         OSMutexPend(&WDog_Mutex, 0, OS_OPT_PEND_BLOCKING, NULL, &err);

--- a/Apps/Src/Task_CANBusConsumer.c
+++ b/Apps/Src/Task_CANBusConsumer.c
@@ -11,7 +11,7 @@ void Task_CANBusConsumer(void *p_arg) {
 
     CANMSG_t message;
 
-    CANbus_Init();
+    CANbus_Init((bool) p_arg);
     
     while(1) {
         // BLOCKING =====================

--- a/Apps/Src/Task_CANBusConsumer.c
+++ b/Apps/Src/Task_CANBusConsumer.c
@@ -3,28 +3,20 @@
 #include "Tasks.h"
 #include "BSP_CAN.h"
 #include "CANbus.h"
+#include "CAN_Queue.h"
 
 
 void Task_CANBusConsumer(void *p_arg) {
     (void)p_arg;
 
-    OS_ERR err;
-    OS_MSG_SIZE msg_size;
-    CPU_TS ts;
-    CANMSG_t *message;
+    CANMSG_t message;
 
     CANbus_Init();
     
     while(1) {
         // BLOCKING =====================
         // Wait for CAN Q to have message
-        message = (CANMSG_t *)OSQPend(&CANBus_MsgQ,
-                                    0,  //timeout
-                                    OS_OPT_PEND_BLOCKING,   //optimization
-                                    &msg_size,  
-                                    &ts,    //pointer to variable that will recieve timestamp of when the message was recivied.
-                                    &err);
-        assertOSError(err);
-        CANbus_BlockAndSend(message->id, message->payload);
+        CAN_Queue_Pend(&message);
+        CANbus_BlockAndSend(message.id, message.payload);
     }
 }

--- a/Apps/Src/Task_CriticalState.c
+++ b/Apps/Src/Task_CriticalState.c
@@ -6,6 +6,7 @@
 #include "Tasks.h"
 #include "BSP_UART.h"
 #include "Voltage.h"
+#include "CAN_Queue.h"
 
 
 void Task_CriticalState(void *p_arg) {
@@ -26,10 +27,10 @@ void Task_CriticalState(void *p_arg) {
     // Push All Clear message to CAN Q
     CANMSG.id = ALL_CLEAR;
     CANMSG.payload = CanPayload;
-    OSQPost(&CANBus_MsgQ, &CANMSG, 1, OS_OPT_POST_FIFO, &err);
+    CAN_Queue_Post(CANMSG);
     // Push Contactor State message to CAN Q
     CANMSG.id = CONTACTOR_STATE;
-    OSQPost(&CANBus_MsgQ, &CANMSG, 1, OS_OPT_POST_FIFO, &err);
+    CAN_Queue_Post(CANMSG);
     OSTaskDel(NULL, &err); // Delete task
     
 }

--- a/Apps/Src/Task_Init.c
+++ b/Apps/Src/Task_Init.c
@@ -2,6 +2,7 @@
 #include "os.h"
 #include "config.h"
 #include "Tasks.h"
+#include "CAN_Queue.h"
 
 #ifndef SIMULATION
 #include "stm32f4xx.h"
@@ -172,10 +173,7 @@ void Task_Init(void *p_arg) {
 				OS_OPT_TASK_STK_CHK | OS_OPT_TASK_SAVE_FP,	// Options
 				&err);					// return err code}
         
-        OSQCreate(&CANBus_MsgQ,
-                "CANBus Message Queue",
-                CANBUS_QUEUE_LENGTH,
-                &err);
+		CAN_Queue_Init();
         assertOSError(err);
 	//delete task
 	OSTaskDel(NULL, &err); // Delete task

--- a/Apps/Src/Task_Init.c
+++ b/Apps/Src/Task_Init.c
@@ -134,7 +134,7 @@ void Task_Init(void *p_arg) {
         OSTaskCreate(&CANBusConsumer_TCB,				// TCB
 				"TASK_CANBUS_CONSUMER_PRIO",	// Task Name (String)
 				Task_CANBusConsumer,				// Task function pointer
-				(void *)0,				// Task function args
+				(void *)false,				// don't use loopback mode
 				TASK_CANBUS_CONSUMER_PRIO,			// Priority
 				CANBusConsumer_Stk,				// Stack
 				WATERMARK_STACK_LIMIT,	// Watermark limit for debugging

--- a/Apps/Src/Task_VoltTempMonitor.c
+++ b/Apps/Src/Task_VoltTempMonitor.c
@@ -7,6 +7,7 @@
 #include "BSP_Fans.h"
 #include "CANbus.h"
 #include "Amps.h"
+#include "CAN_Queue.h"
 
 //declared in Tasks.c
 extern cell_asic Minions[NUM_MINIONS];
@@ -60,7 +61,7 @@ void Task_VoltTempMonitor(void *p_arg) {
             CanData.w = voltage;
             CanPayload.data = CanData;
             CanMsg.payload = CanPayload;
-            OSQPost(&CANBus_MsgQ, &CanMsg, sizeof(CanMsg), OS_OPT_POST_FIFO, &err);
+            CAN_Queue_Post(CanMsg);
         }
 
         // BLOCKING =====================
@@ -114,7 +115,7 @@ void Task_VoltTempMonitor(void *p_arg) {
                 CanData.b = 0;
                 CanPayload.data = CanData;
                 CanMsg.payload = CanPayload;
-                OSQPost(&CANBus_MsgQ, &CanMsg, sizeof(CanMsg), OS_OPT_POST_FIFO, &err);
+                CAN_Queue_Post(CanMsg);
             }
         }
         //Send measurements to CAN queue
@@ -126,7 +127,7 @@ void Task_VoltTempMonitor(void *p_arg) {
                     CanData.w = (uint32_t)Temperature_GetSingleTempSensor(i, j);
                     CanPayload.data = CanData;
                     CanMsg.payload = CanPayload;
-                    OSQPost(&CANBus_MsgQ, &CanMsg, sizeof(CanMsg), OS_OPT_POST_FIFO, &err);
+                    CAN_Queue_Post(CanMsg);
                 }
             }
         }

--- a/Apps/Src/Tasks.c
+++ b/Apps/Src/Tasks.c
@@ -43,11 +43,6 @@ CPU_STK Idle_Stk[TASK_IDLE_STACK_SIZE];
 CPU_STK Init_Stk[TASK_INIT_STACK_SIZE];
 
 /**
- * @brief   Queue for pushing and popping CAN Messages
- */
-OS_Q CANBus_MsgQ;
-
-/**
  * Semaphores
  */
 OS_SEM SafetyCheck_Sem4;

--- a/BSP/Inc/BSP_CAN.h
+++ b/BSP/Inc/BSP_CAN.h
@@ -8,11 +8,12 @@
 
 /**
  * @brief   Initializes the CAN module that communicates with the rest of the electrical system.
- * @param   rxEvent : the function to execute when recieving a message. NULL for no action.
- * @param   txEnd   : the function to execute after transmitting a message
+ * @param   rxEvent     : the function to execute when recieving a message. NULL for no action.
+ * @param   txEnd       : the function to execute after transmitting a message. NULL for no action.
+ * @param   loopback    : if we should use loopback mode (for testing)
  * @return  None
  */
-void BSP_CAN_Init(void (*rxEvent)(void), void (*txEnd)(void));
+void BSP_CAN_Init(void (*rxEvent)(void), void (*txEnd)(void), bool loopback);
 
 /**
  * @brief   Transmits the data onto the CAN bus with the specified id

--- a/BSP/STM32F413/Src/BSP_CAN.c
+++ b/BSP/STM32F413/Src/BSP_CAN.c
@@ -3,7 +3,6 @@
 #include "BSP_CAN.h"
 #include "stm32f4xx.h"
 #include "os.h"
-#include "BSP_Lights.h"
 
 // The message information that we care to receive
 typedef struct _msg {

--- a/BSP/STM32F413/Src/BSP_CAN.c
+++ b/BSP/STM32F413/Src/BSP_CAN.c
@@ -3,6 +3,7 @@
 #include "BSP_CAN.h"
 #include "stm32f4xx.h"
 #include "os.h"
+#include "BSP_Lights.h"
 
 // The message information that we care to receive
 typedef struct _msg {
@@ -28,11 +29,12 @@ static void (*gTxEnd)(void);
 
 /**
  * @brief   Initializes the CAN module that communicates with the rest of the electrical system.
- * @param   rxEvent : the function to execute when recieving a message. NULL for no action.
- * @param   txEnd   : the function to execute after transmitting a message. NULL for no action.
+ * @param   rxEvent     : the function to execute when recieving a message. NULL for no action.
+ * @param   txEnd       : the function to execute after transmitting a message. NULL for no action.
+ * @param   loopback    : if we should use loopback mode (for testing)
  * @return  None
  */
-void BSP_CAN_Init(void (*rxEvent)(void), void (*txEnd)(void)) {
+void BSP_CAN_Init(void (*rxEvent)(void), void (*txEnd)(void), bool loopback) {
     GPIO_InitTypeDef GPIO_InitStructure;
     CAN_InitTypeDef CAN_InitStructure;
     NVIC_InitTypeDef NVIC_InitStructure;
@@ -76,7 +78,7 @@ void BSP_CAN_Init(void (*rxEvent)(void), void (*txEnd)(void)) {
     CAN_InitStructure.CAN_NART = DISABLE;
     CAN_InitStructure.CAN_RFLM = DISABLE;
     CAN_InitStructure.CAN_TXFP = DISABLE;
-    CAN_InitStructure.CAN_Mode = CAN_Mode_Normal;
+    CAN_InitStructure.CAN_Mode = (loopback ? CAN_Mode_LoopBack: CAN_Mode_Normal);
     CAN_InitStructure.CAN_SJW  = CAN_SJW_1tq;
 
     /* CAN Baudrate = 125 KBps
@@ -118,15 +120,18 @@ void BSP_CAN_Init(void (*rxEvent)(void), void (*txEnd)(void)) {
 
     // Enable Rx interrupts
     NVIC_InitStructure.NVIC_IRQChannel = CAN1_RX0_IRQn;
-    NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 0x0;
-    NVIC_InitStructure.NVIC_IRQChannelSubPriority = 0x0;
+    NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 0x1;
+    NVIC_InitStructure.NVIC_IRQChannelSubPriority = 0x1;
     NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
     NVIC_Init(&NVIC_InitStructure);	
 
     if(NULL != txEnd) {
+        // set up CAN Tx interrupts
+        CAN_ITConfig(CAN1, CAN_IT_TME, ENABLE);
+
         // Enable Tx Interrupts
         NVIC_InitStructure.NVIC_IRQChannel = CAN1_TX_IRQn;
-        NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 0x0; // TODO: assess both of these priority settings
+        NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 0x1; // TODO: assess both of these priority settings
         NVIC_InitStructure.NVIC_IRQChannelSubPriority = 0x0;
         NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
         NVIC_Init(&NVIC_InitStructure);
@@ -180,6 +185,8 @@ ErrorStatus BSP_CAN_Read(uint32_t *id, uint8_t *data) {
     return SUCCESS;
 }
 
+// This probably doesn't work because it's missing the equivalent fixes to the Tx Handler,
+// but it isn't part of the BPS requirements, so I'm not going to mess with it until I need it 
 void CAN1_RX0_IRQHandler(void) {
     #ifdef RTOS
     CPU_SR_ALLOC();

--- a/BSP/STM32F413/Src/BSP_UART.c
+++ b/BSP/STM32F413/Src/BSP_UART.c
@@ -70,7 +70,7 @@ static void USART_BLE_Init() {
 
     // Enable NVIC
     NVIC_InitTypeDef NVIC_InitStructure;
-    NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 1;
+    NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 2;
     NVIC_InitStructure.NVIC_IRQChannelSubPriority = 1;
     NVIC_InitStructure.NVIC_IRQChannel = USART2_IRQn;
     NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
@@ -120,7 +120,7 @@ static void USART_USB_Init() {
     // Enable NVIC
     NVIC_InitTypeDef NVIC_InitStructure;
   	NVIC_InitStructure.NVIC_IRQChannel = USART3_IRQn;
-    NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 1;
+    NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 2;
     NVIC_InitStructure.NVIC_IRQChannelSubPriority = 0;
     NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
     NVIC_Init(&NVIC_InitStructure);

--- a/BSP/Simulator/Src/BSP_CAN.c
+++ b/BSP/Simulator/Src/BSP_CAN.c
@@ -20,7 +20,7 @@ static const char* file = GET_CSV_PATH(CAN_CSV_FILE);
 
 
 
-void BSP_CAN_Init(void (*rxEvent)(void), void (*txEnd)(void)) {
+void BSP_CAN_Init(void (*rxEvent)(void), void (*txEnd)(void), bool loopback) {
 #if 0   // TODO: replace with interrupt-capable code
     FILE* fp = fopen(file, "w");
     if(!fp) {

--- a/Config/Inc/config.h
+++ b/Config/Inc/config.h
@@ -54,14 +54,14 @@ typedef enum SafetyStatus_e {SAFE = 0, DANGER = 1, OVERVOLTAGE = 2, UNDERVOLTAGE
 //--------------------------------------------------------------------------------
 // Voltage Sensor Configurations
 // Defines how many voltage sensors are connected to each board
-#define MAX_VOLT_SENSORS_PER_MINION_BOARD	6	// User defined. The LTC6811 can actually measure 12 modules.
-#define NUM_PINS_PER_LTC 					7
-#define TOTAL_VOLT_WIRES					NUM_PINS_PER_LTC*NUM_MINIONS - 1
+#define MAX_VOLT_SENSORS_PER_MINION_BOARD	8	// User defined. The LTC6811 can actually measure 12 modules.
+#define NUM_PINS_PER_LTC 					(MAX_VOLT_SENSORS_PER_MINION_BOARD + 1) // one extra for ground
+#define TOTAL_VOLT_WIRES					(NUM_PINS_PER_LTC * NUM_MINIONS - 1)
 
 //--------------------------------------------------------------------------------
 // Temperature Sensor Configurations
 // Define how many temperature sensors are connected to each board
-#define MAX_TEMP_SENSORS_PER_MINION_BOARD	12
+#define MAX_TEMP_SENSORS_PER_MINION_BOARD	(MAX_VOLT_SENSORS_PER_MINION_BOARD * NUM_TEMP_SENSORS_PER_MOD)
 
 //--------------------------------------------------------------------------------
 // HeartBeat Delay Ticks

--- a/Drivers/Inc/CANbus.h
+++ b/Drivers/Inc/CANbus.h
@@ -17,7 +17,6 @@ typedef enum {
     SOC_DATA = 0x106,
     WDOG_TRIGGERED = 0x107,
     CAN_ERROR = 0x108,
-    MOTOR_DISABLE = 0x10A,
     CHARGE_ENABLE = 0x10C
 } CANId_t;
 
@@ -46,10 +45,10 @@ typedef struct {
 
 /**
  * @brief   Initializes the CAN system
- * @param   None
+ * @param   loopback	: if we should use loopback mode (for testing)	
  * @return  None
  */
-void CANbus_Init(void);
+void CANbus_Init(bool loopback);
 
 /**
  * @brief   Transmits data onto the CANbus. This is non-blocking and will fail with an error if

--- a/Tests/Test_Amperes_Task.c
+++ b/Tests/Test_Amperes_Task.c
@@ -8,6 +8,7 @@
 #include "stm32f4xx.h"
 #include "BSP_Lights.h"
 #include "BSP_PLL.h"
+#include "CAN_Queue.h"
 
 /******************************************************************************
  * Amperes Task Test Plan
@@ -115,10 +116,7 @@ void Task1(void *p_arg){
             &err);					// return err code
         
     // Initialize CAN queue
-    OSQCreate(&CANBus_MsgQ,
-            "CANBus Message Queue",
-            CANBUS_QUEUE_LENGTH,
-            &err);
+    CAN_Queue_Init();
     assertOSError(err);
 
     // get contactor to close without temperature or voltage readings

--- a/Tests/Test_Amperes_Task.c
+++ b/Tests/Test_Amperes_Task.c
@@ -104,7 +104,7 @@ void Task1(void *p_arg){
     OSTaskCreate(&CANBusConsumer_TCB,				// TCB
             "TASK_CANBUS_CONSUMER_PRIO",	// Task Name (String)
             Task_CANBusConsumer,				// Task function pointer
-            (void *)0,				// Task function args
+            (void *)true,				// Use loopback mode
             TASK_CANBUS_CONSUMER_PRIO,			// Priority
             CANBusConsumer_Stk,				// Stack
             WATERMARK_STACK_LIMIT,	// Watermark limit for debugging

--- a/Tests/Test_BSP_CAN.c
+++ b/Tests/Test_BSP_CAN.c
@@ -9,8 +9,8 @@ int main(void){
    uint8_t readData[8] = {0,0,0,0,0,0,0,0};
    uint32_t id[1];
   
-   uint8_t length = 1;
-   BSP_CAN_Init(NULL, NULL);
+   uint8_t length = 8;
+   BSP_CAN_Init(NULL, NULL, false);
    
    while(1) {
       BSP_CAN_Write(0x10A, message, length);

--- a/Tests/Test_CAN_Task.c
+++ b/Tests/Test_CAN_Task.c
@@ -126,7 +126,7 @@ void Task1(void *p_arg){
     OSTaskCreate(&CANBusConsumer_TCB,				// TCB
             "TASK_CANBUS_CONSUMER_PRIO",	// Task Name (String)
             Task_CANBusConsumer,				// Task function pointer
-            (void *)0,				// Task function args
+            (void *)true,				// Use loopback mode
             TASK_CANBUS_CONSUMER_PRIO,			// Priority
             CANBusConsumer_Stk,				// Stack
             WATERMARK_STACK_LIMIT,	// Watermark limit for debugging

--- a/Tests/Test_CAN_Task.c
+++ b/Tests/Test_CAN_Task.c
@@ -8,6 +8,7 @@
 #include "stm32f4xx.h"
 #include "BSP_Lights.h"
 #include "BSP_PLL.h"
+#include "CAN_Queue.h"
 
 /******************************************************************************
  * CAN Task Test Plan
@@ -65,7 +66,7 @@ void Task_Spam(void *p_arg){
             CanData.w = voltage; //send data in millivolts
             CanPayload.data = CanData;
             CanMsg.payload = CanPayload;
-            OSQPost(&CANBus_MsgQ, &CanMsg, sizeof(CanMsg), OS_OPT_POST_FIFO, &err);
+            CAN_Queue_Post(CanMsg);
         }
 
         // Send message if car should be allowed to charge or not
@@ -75,7 +76,7 @@ void Task_Spam(void *p_arg){
         CanData.b = false;
         CanPayload.data = CanData;
         CanMsg.payload = CanPayload;
-        OSQPost(&CANBus_MsgQ, &CanMsg, sizeof(CanMsg), OS_OPT_POST_FIFO, &err);
+        CAN_Queue_Post(CanMsg);
 
         //Send fake temperature measurements to CAN queue
         CanMsg.id = TEMP_DATA;
@@ -87,7 +88,7 @@ void Task_Spam(void *p_arg){
                     CanData.w += 500; // generate fake temperatures
                     CanPayload.data = CanData;
                     CanMsg.payload = CanPayload;
-                    OSQPost(&CANBus_MsgQ, &CanMsg, sizeof(CanMsg), OS_OPT_POST_FIFO, &err);
+                    CAN_Queue_Post(CanMsg);
                 }
             }
         }
@@ -137,10 +138,7 @@ void Task1(void *p_arg){
             &err);					// return err code
         
         // Initialize CAN queue
-        OSQCreate(&CANBus_MsgQ,
-                "CANBus Message Queue",
-                CANBUS_QUEUE_LENGTH,
-                &err);
+        CAN_Queue_Init();
         assertOSError(err);
 	//delete task
 	OSTaskDel(NULL, &err); // Delete task

--- a/Tests/Test_RTOS_CAN.c
+++ b/Tests/Test_RTOS_CAN.c
@@ -23,7 +23,7 @@ void Task1(void *p_arg){
     OS_CPU_SysTickInit(SystemCoreClock / (CPU_INT32U) OSCfg_TickRate_Hz);
     
     BSP_Lights_Init();
-    CANbus_Init();
+    CANbus_Init(true);
    
     while(1) {
         CANbus_BlockAndSend(id, payload);


### PR DESCRIPTION
I fixed the following bugs (verified on hardware using Test_BSP_CAN, Test_RTOS_CAN, and Test_CAN_Task):
- Fixed initialization of CAN Tx interrupts in BSP
- Allowed BSP_CAN and CANBus to be initialized in loopback mode
- Updated list of valid CAN messages and associated switch statement
- Fixed CANBus error handling that was causing resource leak
- Changed some defines in config.h to the correct values