### PR TITLE
Bsp timert bugs

### DIFF
--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -17,8 +17,8 @@ jobs:
         sudo apt -y install gcc-arm-none-eabi
     - name: Initialize submodules
       run: git submodule update --init --recursive
-    - name: make simulator
-      run: make simulator
+#    - name: make simulator
+#      run: make simulator
     - name: clean
       run: make clean
     - name: make stm32f413

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,7 +16,8 @@
         "canbus.h": "c",
         "tasks.h": "c",
         "voltage.h": "c",
-        "bsp_spi.h": "c"
+        "bsp_spi.h": "c",
+        "charge.h": "c"
     },
     "python.linting.pylintEnabled": true,
     "python.linting.enabled": true,

--- a/Apps/Src/Charge.c
+++ b/Apps/Src/Charge.c
@@ -34,10 +34,10 @@ void Charge_Calculate(int32_t milliamps){
 	
 	int64_t micro_sec = (int64_t)BSP_Timer_GetMicrosElapsed();
 	int64_t millis = (int64_t)milliamps;
-	
-	charge -= (int32_t) (micro_sec * millis
-						* ((100 * CHARGE_RESOLUTION_SCALE) / 1000000)
-						/ 3600 / MAX_CHARGE_MILLI_AMP_HRS);
+	                                                                   // Psuedo code that represents what this math does. In the coded math, order of operations is very important to avoid overflow 
+	charge -= (int32_t) (micro_sec * millis                            // microseconds / 1,000,000 / 3600 = hours_elapsed
+						* ((100 * CHARGE_RESOLUTION_SCALE) / 1000000)  // (milliamp * hours_elapsed) / max_amp_hour = percent_of_charge_elapsed
+						/ 3600 / MAX_CHARGE_MILLI_AMP_HRS);            // percent_charge_elapsed * 100 * charge resolution = a much larger number which represents the charge depleted
 }
 
 /** Charge_Calibrate

--- a/Apps/Src/Charge.c
+++ b/Apps/Src/Charge.c
@@ -26,17 +26,17 @@ void Charge_Init(void){
 
 /** Charge_Calculate
  * Calculates new Charge depending on the current reading
- * @param current reading from current sensors. Fixed point of 0.001 (1.500 Amps = 1500)
+ * @param milliamps reading from current sensors. Fixed point of 0.001 (1.500 Amps = 1500)
  * not a constant samping. Add on however much from the previous
  */
 void Charge_Calculate(int32_t milliamps){ 
 	/* Update Charge, units of 0.01% */
-	// TODO: I am preserving the existing math to make this PR easier to follow. Fixing it is a problem for issue #390
-	//charge -= (int32_t) (CHARGE_RESOLUTION_SCALE * 100 * ticksElapsed * milliamps
-	//						/ clockFrequency / 60 / 60 / MAX_CHARGE_MILLI_AMP_HRS);
-
-	uint32_t micro_sec = BSP_Timer_GetMicrosElapsed();
-	charge -= (int32_t) (micro_sec * milliamps
+	
+	int64_t micro_sec = (int64_t)BSP_Timer_GetMicrosElapsed();
+	int64_t millis = (int64_t)milliamps;
+	// Test: Ensure that the microseconds elapsed are accurate
+	//printf("microseconds elapsed (should be 100,000): %ld\n\r", micro_sec);
+	charge -= (int32_t) (micro_sec * millis
 						* ((100 * CHARGE_RESOLUTION_SCALE) / 1000000)
 						/ 3600 / MAX_CHARGE_MILLI_AMP_HRS);
 }

--- a/Apps/Src/Charge.c
+++ b/Apps/Src/Charge.c
@@ -8,7 +8,7 @@
 
 #define CHARGE_RESOLUTION_SCALE 1000000     // What we need to multiply 100% by before storing. Ensure it is >= 10,000 to avoid depleted charge calculation issues
 #define MAX_CHARGE_MILLI_AMP_HRS 41300    // In miliamp-hours (mAh), calculated from 12950(mah)*14 bats in parallel
-static int32_t charge;  // % of charge left with 0.01% resolution
+static int32_t charge;  // % of charge left with 0.000001% resolution
 
 /** Charge_Init
  * Initializes necessary timer and values to begin state of charge
@@ -30,12 +30,11 @@ void Charge_Init(void){
  * not a constant samping. Add on however much from the previous
  */
 void Charge_Calculate(int32_t milliamps){ 
-	/* Update Charge, units of 0.01% */
+	/* Update Charge, units of 0.000001% . 100,000,000 is charge at 100% */
 	
 	int64_t micro_sec = (int64_t)BSP_Timer_GetMicrosElapsed();
 	int64_t millis = (int64_t)milliamps;
-	// Test: Ensure that the microseconds elapsed are accurate
-	//printf("microseconds elapsed (should be 100,000): %ld\n\r", micro_sec);
+	
 	charge -= (int32_t) (micro_sec * millis
 						* ((100 * CHARGE_RESOLUTION_SCALE) / 1000000)
 						/ 3600 / MAX_CHARGE_MILLI_AMP_HRS);
@@ -57,7 +56,7 @@ void Charge_Calibrate(int8_t faultType){
 
 /** Charge_GetPercent
  * Gets the percentage of charge left in the battery pack
- * @return fixed point percentage. Resolution = 0.01 (45.55% = 4555)
+ * @return fixed point percentage. Resolution = 0.000001% (45,550,000 = 45.55%)
  */
 uint32_t Charge_GetPercent(void){
 	return charge;
@@ -66,7 +65,7 @@ uint32_t Charge_GetPercent(void){
 /** Charge_SetAccum 
  * Sets the accumulator of the coloumb counting algorithm
  * @param accumulator value in percent of total charge,
- *                    with a resolution = 0.01%
+ *                    with a resolution = 0.000001% (100,000,000 = 100%)
  */
 void Charge_SetAccum(int32_t accum){
 	charge = accum;

--- a/Apps/Src/Charge.c
+++ b/Apps/Src/Charge.c
@@ -32,10 +32,10 @@ void Charge_Init(void){
  */
 void Charge_Calculate(int32_t milliamps){ 
 	
-	uint32_t counter = BSP_Timer_GetTicksElapsed();
+	//uint32_t counter = BSP_Timer_GetTicksElapsed();
 	
-	uint32_t ticksElapsed = 0xFFFF - counter;	// I hate this, but fixing BSP_Timer_GetTicksElapsed() is beyond the scope of this PR. Opened issue #389 for this
-
+	//uint32_t ticksElapsed = 0xFFFF - counter;	// I hate this, but fixing BSP_Timer_GetTicksElapsed() is beyond the scope of this PR. Opened issue #389 for this
+	uint32_t ticksElapsed = BSP_Timer_GetTicksElapsed(); // BSP_Timer_GetTicks now counts up from 0, so return value is accurate
 	uint32_t clockFrequency = BSP_Timer_GetRunFreq();
 
 	/* Update Charge, units of 0.01% */

--- a/Apps/Src/Charge.c
+++ b/Apps/Src/Charge.c
@@ -7,9 +7,8 @@
 #include "BSP_Timer.h"
 
 #define CHARGE_RESOLUTION_SCALE 100     // What we need to multiply 100% by before storing
-#define MAX_CHARGE_AMP_HRS 1000*1000    // In amp-hours (Ah), for now it is a dummy value
-
-static uint32_t charge;  // % of charge left with 0.01% resolution
+#define MAX_CHARGE_MILLI_AMP_HRS 41300    // In miliamp-hours (mAh), calculated from 12950(mah)*14 bats in parallel
+static int32_t charge;  // % of charge left with 0.01% resolution
 
 /** Charge_Init
  * Initializes necessary timer and values to begin state of charge
@@ -40,8 +39,8 @@ void Charge_Calculate(int32_t milliamps){
 
 	/* Update Charge, units of 0.01% */
 	// TODO: I am preserving the existing math to make this PR easier to follow. Fixing it is a problem for issue #390
-	charge += (uint32_t) (CHARGE_RESOLUTION_SCALE * 100 * ticksElapsed * milliamps 
-							/ clockFrequency / 1000 / 60 / 60 / 60 / MAX_CHARGE_AMP_HRS);
+	charge -= (int32_t) (CHARGE_RESOLUTION_SCALE * 100 * ticksElapsed * milliamps
+							/ clockFrequency / 60 / 60 / MAX_CHARGE_MILLI_AMP_HRS);
 }
 
 /** Charge_Calibrate

--- a/BSP/Inc/BSP_Timer.h
+++ b/BSP/Inc/BSP_Timer.h
@@ -33,4 +33,11 @@ uint32_t BSP_Timer_GetTicksElapsed(void);
  */
 uint32_t BSP_Timer_GetRunFreq(void);
 
+/**
+ * @brief   Calculates the microseconds passed since last calling BSP_TimerGetTicksElapsed()
+ * @param   None
+ * @return  Microseconds
+ */
+uint32_t BSP_Timer_GetMicrosElapsed();
+
 #endif

--- a/BSP/Inc/BSP_Timer.h
+++ b/BSP/Inc/BSP_Timer.h
@@ -38,6 +38,6 @@ uint32_t BSP_Timer_GetRunFreq(void);
  * @param   None
  * @return  Microseconds
  */
-uint32_t BSP_Timer_GetMicrosElapsed();
+uint32_t BSP_Timer_GetMicrosElapsed(void);
 
 #endif

--- a/BSP/STM32F413/Src/BSP_Timer.c
+++ b/BSP/STM32F413/Src/BSP_Timer.c
@@ -14,7 +14,7 @@ void BSP_Timer_Init(void) {
 	TIM_TimeBaseInitTypeDef Init_TIM2;
 	
 	Init_TIM2.TIM_Prescaler = 1;
-	Init_TIM2.TIM_CounterMode = TIM_CounterMode_Down;
+	Init_TIM2.TIM_CounterMode = TIM_CounterMode_Up;
 	Init_TIM2.TIM_Period = 0xFFFF-1;
 	Init_TIM2.TIM_ClockDivision = TIM_CKD_DIV1;
 	Init_TIM2.TIM_RepetitionCounter = 0;

--- a/BSP/STM32F413/Src/BSP_Timer.c
+++ b/BSP/STM32F413/Src/BSP_Timer.c
@@ -56,7 +56,7 @@ uint32_t BSP_Timer_GetRunFreq(void) {
     RCC_ClocksTypeDef RCC_Clocks;
 	RCC_GetClocksFreq(&RCC_Clocks);
 
-    return RCC_Clocks.SYSCLK_Frequency;
+    return RCC_Clocks.PCLK2_Frequency; // Tested using UART and this appears to be the proper clock used by the timer.
 }
 
 /**
@@ -65,12 +65,9 @@ uint32_t BSP_Timer_GetRunFreq(void) {
  * @return  Microseconds 
  */
 uint32_t BSP_Timer_GetMicrosElapsed(void) {
-	RCC_ClocksTypeDef rccClocks;
-	RCC_GetClocksFreq(&rccClocks);
-	uint32_t freq = rccClocks.PCLK2_Frequency; // Tested using UART and this appears to be the proper clock.
+	
 	uint32_t ticks = BSP_Timer_GetTicksElapsed();
-	printf("ticks elapsed : %ld\n\r", ticks);
+	uint32_t freq = BSP_Timer_GetRunFreq();
 	uint32_t micros_elap = ticks * (PRESCALER + 1) / (freq / MICROSEC_CON); // Math to ensure that we do not overflow (16Mhz or 80Mhz)
-	printf("micros elapsed : %ld\n\r", micros_elap);
 	return micros_elap;
 } 

--- a/BSP/STM32F413/Src/BSP_Timer.c
+++ b/BSP/STM32F413/Src/BSP_Timer.c
@@ -16,12 +16,13 @@ void BSP_Timer_Init(void) {
 	RCC_APB1PeriphClockCmd(RCC_APB1Periph_TIM2, ENABLE);
 	TIM_TimeBaseInitTypeDef Init_TIM2;
 	
-	Init_TIM2.TIM_Prescaler = PRESCALER;
-	Init_TIM2.TIM_CounterMode = TIM_CounterMode_Up;
-	Init_TIM2.TIM_Period = 0xFFFF;
-	Init_TIM2.TIM_ClockDivision = TIM_CKD_DIV1;
+	Init_TIM2.TIM_Prescaler = PRESCALER; // In every tick, there are 2000 clock cycles. (A 0 prescaler is actually 1, so 1999 = 2000)
+	Init_TIM2.TIM_CounterMode = TIM_CounterMode_Up; // Count from 0 to Period value below
+	Init_TIM2.TIM_Period = 0xFFFF;  // Max value of the counter before resetting to 0
+	Init_TIM2.TIM_ClockDivision = TIM_CKD_DIV1;  // Clock divide by 1
 	Init_TIM2.TIM_RepetitionCounter = 0;
-	
+	// With this configuration, it would take 3.27 seconds for the counter to overflow and reset to 0
+
 	TIM_TimeBaseInit(TIM2, &Init_TIM2);
 }
 
@@ -55,7 +56,7 @@ uint32_t BSP_Timer_GetTicksElapsed(void) {
 uint32_t BSP_Timer_GetRunFreq(void) {
     RCC_ClocksTypeDef RCC_Clocks;
 	RCC_GetClocksFreq(&RCC_Clocks);
-
+	// Return value is 40,000,000
     return RCC_Clocks.PCLK2_Frequency; // Tested using UART and this appears to be the proper clock used by the timer.
 }
 

--- a/BSP/STM32F413/Src/BSP_Timer.c
+++ b/BSP/STM32F413/Src/BSP_Timer.c
@@ -60,7 +60,7 @@ uint32_t BSP_Timer_GetRunFreq(void) {
 }
 
 /**
- * @brief   Gives a standard unit for time elapsed in microseconds since calling BSP_Timer_GetRunFreq()
+ * @brief   Gives a standard unit for time elapsed in microseconds since calling BSP_Timer_GetTicksElapsed()
  * @param   None
  * @return  Microseconds 
  */

--- a/BSP/STM32F413/Src/BSP_Timer.c
+++ b/BSP/STM32F413/Src/BSP_Timer.c
@@ -67,6 +67,7 @@ uint32_t BSP_Timer_GetRunFreq(void) {
 uint32_t BSP_Timer_GetMicrosElapsed(void) {
 	uint32_t freq = BSP_Timer_GetRunFreq();
 	uint32_t ticks = BSP_Timer_GetTicksElapsed();
-	uint32_t micros_elap = MICROSEC_CON * ticks * PRESCALER / freq;
+	printf("ticks elapsed : %ld\n\r", ticks);
+	uint32_t micros_elap = ticks * PRESCALER / (freq / MICROSEC_CON); // Math to ensure that we do not overflow (16Mhz or 80Mhz)
 	return micros_elap;
-}
+} 

--- a/BSP/STM32F413/Src/BSP_Timer.c
+++ b/BSP/STM32F413/Src/BSP_Timer.c
@@ -3,6 +3,8 @@
 #include "BSP_Timer.h"
 #include "stm32f4xx.h"
 
+static const PRESCALER = 2000;
+
 /**
  * @brief   Initialize the timer for time measurements.
  * @param   None
@@ -13,7 +15,7 @@ void BSP_Timer_Init(void) {
 	RCC_APB1PeriphClockCmd(RCC_APB1Periph_TIM2, ENABLE);
 	TIM_TimeBaseInitTypeDef Init_TIM2;
 	
-	Init_TIM2.TIM_Prescaler = 1;
+	Init_TIM2.TIM_Prescaler = PRESCALER;
 	Init_TIM2.TIM_CounterMode = TIM_CounterMode_Up;
 	Init_TIM2.TIM_Period = 0xFFFF-1;
 	Init_TIM2.TIM_ClockDivision = TIM_CKD_DIV1;
@@ -54,4 +56,9 @@ uint32_t BSP_Timer_GetRunFreq(void) {
 	RCC_GetClocksFreq(&RCC_Clocks);
 
     return RCC_Clocks.SYSCLK_Frequency;
+}
+
+// TODO: add function description
+uint32_t BSP_Timer_GetMicrosElapsed(void) {
+	// TODO: implement this
 }

--- a/BSP/STM32F413/Src/BSP_Timer.c
+++ b/BSP/STM32F413/Src/BSP_Timer.c
@@ -3,8 +3,8 @@
 #include "BSP_Timer.h"
 #include "stm32f4xx.h"
 
-static const PRESCALER = 2000;
-static const MICROSEC_CON = 1000000;
+static const int PRESCALER = 2000;
+static const int MICROSEC_CON = 1000000;
 
 /**
  * @brief   Initialize the timer for time measurements.

--- a/BSP/STM32F413/Src/BSP_Timer.c
+++ b/BSP/STM32F413/Src/BSP_Timer.c
@@ -4,6 +4,7 @@
 #include "stm32f4xx.h"
 
 static const PRESCALER = 2000;
+static const MICROSEC_CON = 1000000;
 
 /**
  * @brief   Initialize the timer for time measurements.
@@ -58,7 +59,14 @@ uint32_t BSP_Timer_GetRunFreq(void) {
     return RCC_Clocks.SYSCLK_Frequency;
 }
 
-// TODO: add function description
+/**
+ * @brief   Gives a standard unit for time elapsed in microseconds since calling BSP_Timer_GetRunFreq()
+ * @param   None
+ * @return  Microseconds 
+ */
 uint32_t BSP_Timer_GetMicrosElapsed(void) {
-	// TODO: implement this
+	uint32_t freq = BSP_Timer_GetRunFreq();
+	uint32_t ticks = BSP_Timer_GetTicksElapsed();
+	uint32_t micros_elap = MICROSEC_CON * ticks * PRESCALER / freq;
+	return micros_elap;
 }

--- a/BSP/STM32F413/Src/BSP_Timer.c
+++ b/BSP/STM32F413/Src/BSP_Timer.c
@@ -3,7 +3,7 @@
 #include "BSP_Timer.h"
 #include "stm32f4xx.h"
 
-static const int PRESCALER = 2000;
+static const int PRESCALER = 1999;
 static const int MICROSEC_CON = 1000000;
 
 /**
@@ -18,7 +18,7 @@ void BSP_Timer_Init(void) {
 	
 	Init_TIM2.TIM_Prescaler = PRESCALER;
 	Init_TIM2.TIM_CounterMode = TIM_CounterMode_Up;
-	Init_TIM2.TIM_Period = 0xFFFF-1;
+	Init_TIM2.TIM_Period = 0xFFFF;
 	Init_TIM2.TIM_ClockDivision = TIM_CKD_DIV1;
 	Init_TIM2.TIM_RepetitionCounter = 0;
 	
@@ -65,9 +65,12 @@ uint32_t BSP_Timer_GetRunFreq(void) {
  * @return  Microseconds 
  */
 uint32_t BSP_Timer_GetMicrosElapsed(void) {
-	uint32_t freq = BSP_Timer_GetRunFreq();
+	RCC_ClocksTypeDef rccClocks;
+	RCC_GetClocksFreq(&rccClocks);
+	uint32_t freq = rccClocks.PCLK2_Frequency; // Tested using UART and this appears to be the proper clock.
 	uint32_t ticks = BSP_Timer_GetTicksElapsed();
 	printf("ticks elapsed : %ld\n\r", ticks);
-	uint32_t micros_elap = ticks * PRESCALER / (freq / MICROSEC_CON); // Math to ensure that we do not overflow (16Mhz or 80Mhz)
+	uint32_t micros_elap = ticks * (PRESCALER + 1) / (freq / MICROSEC_CON); // Math to ensure that we do not overflow (16Mhz or 80Mhz)
+	printf("micros elapsed : %ld\n\r", micros_elap);
 	return micros_elap;
 } 

--- a/Tests/Test_BSP_Timer.c
+++ b/Tests/Test_BSP_Timer.c
@@ -3,17 +3,18 @@
 #include "common.h"
 #include "config.h"
 #include "BSP_Timer.h"
-
+#include "BSP_UART.h"
 
 int main(void){
     uint32_t test;
-    uint32_t delay = 150000000;
-    uint32_t time = 40;        
+    uint32_t delay = 10000000;
+    uint32_t time = 1;        
     
     BSP_Timer_Init();
+    BSP_UART_Init(NULL, NULL, UART_USB);
     BSP_Timer_Start();
     uint32_t freq = BSP_Timer_GetRunFreq();
-    printf("Timer frequency: %ld\n\r", freq);
+    printf("New version \n\r");
     
     while(1){
         test = BSP_Timer_GetTicksElapsed();
@@ -21,13 +22,14 @@ int main(void){
         freq = BSP_Timer_GetRunFreq();
         printf("Timer frequency: %ld\n\r", freq);  
         while(time){                        //this is a delay to prevent the elapsed time being negligible
-            delay = 150000000;
+            delay = 10000000;
             while(delay){
                 delay--;
             }
             time--;
+            printf("Decrement \n\r");
         }
-        time = 40;
+        time = 1;
     }
    
 }

--- a/Tests/Test_BSP_Timer.c
+++ b/Tests/Test_BSP_Timer.c
@@ -13,13 +13,13 @@ int main(void){
     BSP_Timer_Init();
     BSP_Timer_Start();
     uint32_t freq = BSP_Timer_GetRunFreq();
-    printf("Timer frequency: %d\n\r", freq);
+    printf("Timer frequency: %ld\n\r", freq);
     
     while(1){
         test = BSP_Timer_GetTicksElapsed();
-        printf("Ticks elapsed : %d\n\r", test);
+        printf("Ticks elapsed : %ld\n\r", test);
         freq = BSP_Timer_GetRunFreq();
-        printf("Timer frequency: %d\n\r", freq);  
+        printf("Timer frequency: %ld\n\r", freq);  
         while(time){                        //this is a delay to prevent the elapsed time being negligible
             delay = 150000000;
             while(delay){

--- a/Tests/Test_Charge.c
+++ b/Tests/Test_Charge.c
@@ -1,0 +1,67 @@
+#include "common.h"
+#include "config.h"
+#include "Charge.h"
+#include "BSP_Timer.h"
+#include "BSP_UART.h"
+
+#include "os.h"
+#include "Tasks.h"
+#include "stm32f4xx.h"
+#include "BSP_PLL.h"
+
+OS_TCB Task1_TCB;
+CPU_STK Task1_Stk[256];
+uint32_t charge_reading;
+
+void Task1(void *p_arg){
+    BSP_UART_Init(NULL, NULL, UART_USB);
+    Charge_Init();
+    Charge_SetAccum(50000);
+    OS_ERR err;
+    OS_CPU_SysTickInit(SystemCoreClock / (CPU_INT32U) OSCfg_TickRate_Hz);
+   
+    while(1) {
+        printf("Charge after 5Amps for 100 milliseconds : %ld\n\r", charge_reading);
+        Charge_Calculate(5000);
+        charge_reading = Charge_GetPercent();
+        OSTimeDly(10, OS_OPT_TIME_DLY, &err);
+        assertOSError(err);
+    }
+
+    exit(0);
+}
+
+int main(void){
+    
+    
+
+    OS_ERR err;
+    BSP_PLL_Init();
+
+    __disable_irq();
+
+    OSInit(&err);
+    while(err != OS_ERR_NONE);
+
+    OSTaskCreate(&Task1_TCB,
+                "Task 1",
+                Task1,
+                (void *)0,
+                1,
+                Task1_Stk,
+                16,
+                256,
+                0,
+                0,
+                (void *)0,
+                OS_OPT_TASK_SAVE_FP | OS_OPT_TASK_STK_CHK,
+                &err);
+    while(err != OS_ERR_NONE);
+
+    __enable_irq();
+
+    OSStart(&err);
+
+
+    
+}


### PR DESCRIPTION
Timer.c and Charge.c are both altered. Timer.c was changed to use an upcounter and a prescaler to allow .1 seconds to count 2000 ticks. This is used in Get_Ticks_Elapsed to return the proper number of ticks elapsed between function calls. I then added a function called Get_Micros_Elapsed which converts the ticks from the previous function into microseconds and returns that. The use of microseconds is to avoid precision loss within our math in future functions added and modified in this pull request. Additionally, Clark changed Timer_GetRunFreq to return the frequency used by the timer, since the original code I worked on returned a different frequency which ruined the math in returning micro seconds.

Charge.c was altered to use a larger charge resolution scale, to have a more accurate max mAh measurement, and to use unsigned int milliamps instead of floats within the charge calculation to prevent precision loss. Now, within the Charge_Calculate function, charge is decremented in units of .000001%. Finally, there is some type casting to 64 bit unsigned integers within the previous function to prevent overflow issues we had while debugging.

Both functions were tested using UART and the OS sleep function. In our final stage of debugging we used a 100 millisecond interval which at a timer frequency of 40,000,00Hz and a prescaler of 2000 gives us 2000 ticks. Inputting this into the getMicros function returns 100,000 microseconds, which is correct for time between function calls. The rest of the math in Charge_Calculate using 100k microseconds and a reading of 5000 mA returned the proper value to decrement charge by, where 100% charge = 100,000,000.