### PR TITLE
Median filtering

### DIFF
--- a/Apps/Src/EEPROM.c
+++ b/Apps/Src/EEPROM.c
@@ -18,9 +18,20 @@ static const uint32_t EEPROM_TERMINATOR = 0xFFFFFFFF;
 // cached value of end of fault array
 static uint16_t faultArrayEndAddress;
 
+// variables to keep track of repeated EEPROM communcation failures and to disable it if there are too many failures
+static bool EEPROM_errorLoggingDisabled = false;
+static uint16_t EEPROM_consecutiveFaults = 0;
+static const uint16_t EEPROM_MAX_CONSECUTIVE_FAULTS = 5;
+
 // handle errors from M24128 driver
 static uint32_t EEPROM_driverErrorCount = 0;
-#define EEPROM_RETRY(func) while ((func) == ERROR) { ++EEPROM_driverErrorCount; }
+#define EEPROM_RETRY(func) while ((func) == ERROR) { \
+        ++EEPROM_driverErrorCount; \
+        ++EEPROM_consecutiveFaults; \
+        EEPROM_errorLoggingDisabled = (EEPROM_consecutiveFaults > EEPROM_MAX_CONSECUTIVE_FAULTS); \
+        if (EEPROM_errorLoggingDisabled) break; \
+    } \
+    EEPROM_consecutiveFaults = 0;
 
 /** EEPROM_Init
  * Initializes EEPROM application
@@ -33,6 +44,9 @@ void EEPROM_Init(void) {
     uint32_t data = 0;
     faultArrayEndAddress = EEPROM_FAULT_ADDR - sizeof(EEPROM_TERMINATOR);
     while (data != EEPROM_TERMINATOR) {
+        if (EEPROM_errorLoggingDisabled) {
+            return;
+        }
         if (faultArrayEndAddress > EEPROM_FAULT_ADDR + sizeof(EEPROM_TERMINATOR) * MAX_FAULTS) {
             EEPROM_Reset();
             faultArrayEndAddress = EEPROM_FAULT_ADDR;
@@ -88,6 +102,7 @@ void EEPROM_SetCharge(uint32_t charge) {
  * @param error The error to log
  */
 void EEPROM_LogError(uint32_t error) {
+    if (EEPROM_errorLoggingDisabled) return;
     // assumes sizeof(EEPROM_TERMINATOR) == sizeof(error)
     // retry writes if unsuccessful
     EEPROM_RETRY(M24128_Write(faultArrayEndAddress + sizeof(EEPROM_TERMINATOR), sizeof(EEPROM_TERMINATOR), (uint8_t *) &EEPROM_TERMINATOR));
@@ -103,6 +118,8 @@ void EEPROM_LogError(uint32_t error) {
  * @return              the number of errors read
  */
 uint16_t EEPROM_GetErrors(uint32_t *errors, uint16_t maxErrors) {
+    if (EEPROM_errorLoggingDisabled) return 0;
+
     uint16_t numErrors = 0;
     uint16_t addr = EEPROM_FAULT_ADDR;
     for (; (addr < faultArrayEndAddress) && (numErrors < maxErrors); ++numErrors) {

--- a/Apps/Src/Temperature.c
+++ b/Apps/Src/Temperature.c
@@ -10,7 +10,14 @@
 #include "VoltageToTemp.h"
 #include "BSP_PLL.h"
 
+// if you change this, you also need to change the calls to median()
+#define MEDIAN_FILTER_DEPTH 3
+
 void delay_u(uint16_t micro);
+
+// median filter for temperature values
+static int32_t medianFilterIdx = MEDIAN_FILTER_DEPTH - 1;
+static int32_t rawTemperatures[NUM_MINIONS][MAX_TEMP_SENSORS_PER_MINION_BOARD][MEDIAN_FILTER_DEPTH];
 
 // Holds the temperatures in Celsius (Fixed Point with .001 resolution) for each sensor on each board
 static int32_t temperatures[NUM_MINIONS][MAX_TEMP_SENSORS_PER_MINION_BOARD];
@@ -24,6 +31,20 @@ static uint8_t ChargingState;
 // Interface to communicate with LTC6811 (Register values)
 // Temperature.c uses auxiliary registers to view ADC data and COM register for I2C with LTC1380 MUX
 static cell_asic *Minions;
+
+/**
+ * @brief find the median of three values
+ * 
+ * @param a first value
+ * @param b second value
+ * @param c third value
+ * @return the median
+ */
+static inline int32_t median(int32_t a, int32_t b, int32_t c) {
+	if (a <= b && b < c) return b;
+	if (a < b && a > c) return a;
+	return c;
+}
 
 /** Temperature_Init
  * Initializes device drivers including SPI inside LTC6811_init and LTC6811 for Temperature Monitoring
@@ -50,6 +71,17 @@ void Temperature_Init(cell_asic *boards){
 	//release mutex
   	OSMutexPost(&MinionsASIC_Mutex, OS_OPT_POST_NONE, &err);
   	assertOSError(err);
+
+	// set up the median filter with alternating temperatures of 1000 degrees and 0 degrees
+	for (int32_t filterIdx = 0; filterIdx < MEDIAN_FILTER_DEPTH - 1; ++filterIdx) {
+		for (int32_t minion = 0; minion < NUM_MINIONS; ++minion) {
+			for (int32_t sensor = 0; sensor < MAX_TEMP_SENSORS_PER_MINION_BOARD; ++sensor) {
+				rawTemperatures[minion][sensor][filterIdx] = (filterIdx & 0x1) ? 1000000 : 0;
+			}
+		}
+	}
+	// median filter should start pointing to the last set of temperature readings
+	medianFilterIdx = MEDIAN_FILTER_DEPTH - 1;
 
 }
 
@@ -161,8 +193,6 @@ int32_t milliVoltToCelsius(uint32_t milliVolt){
  * @return SUCCESS or ERROR
  */
 ErrorStatus Temperature_UpdateSingleChannel(uint8_t channel){
-	OS_ERR err;
-
 	// Configure correct channel
 	if (ERROR == Temperature_ChannelConfig(channel)) {
 		return ERROR;
@@ -170,21 +200,31 @@ ErrorStatus Temperature_UpdateSingleChannel(uint8_t channel){
 	
 	// Sample ADC channel
 	Temperature_SampleADC(MD_422HZ_1KHZ);
-	
-	//take control of mutex
-  	OSMutexPend(&MinionsASIC_Mutex, 0, OS_OPT_PEND_BLOCKING, NULL, &err);
-	assertOSError(err);
+
+	// update the median filter
 
 	// Convert to Celsius
 	for(int board = 0; board < NUM_MINIONS; board++) {
 		
 		// update adc value from GPIO1 stored in a_codes[0]; 
 		// a_codes[0] is fixed point with .001 resolution in volts -> multiply by .001 * 1000 to get mV in double form
-		temperatures[board][channel] = milliVoltToCelsius(Minions[board].aux.a_codes[0] / 10);
+		rawTemperatures[board][channel][medianFilterIdx] = milliVoltToCelsius(Minions[board].aux.a_codes[0] / 10);
 	}
-	//release mutex
-  	OSMutexPost(&MinionsASIC_Mutex, OS_OPT_POST_NONE, &err);
-  	assertOSError(err);
+
+	// increment the median filter index
+	medianFilterIdx = (medianFilterIdx + 1) % MEDIAN_FILTER_DEPTH;
+
+	// update the filtered values
+	// you need to change this if you change 
+	for (int32_t minion = 0; minion < NUM_MINIONS; ++minion) {
+		for (int32_t sensor = 0; sensor < NUM_TEMP_SENSORS_PER_MOD; ++sensor) {
+			temperatures[minion][sensor] = median(
+													 rawTemperatures[minion][sensor][0],
+													 rawTemperatures[minion][sensor][1],
+													 rawTemperatures[minion][sensor][2]
+												 );
+		}
+	}
 
 	return SUCCESS;
 }


### PR DESCRIPTION
Fix for issue where regen braking will cause spikes in current that create noise on voltage and temperature measurement lines with median filtering.

Also, branched off of the EEPROM fix branch, so this includes the fixes from there