### PR TITLE
RTOS Mutex Pend Wrapper

### DIFF
--- a/Tasks/Inc/RTOS_BPS.h
+++ b/Tasks/Inc/RTOS_BPS.h
@@ -47,7 +47,7 @@ void RTOS_BPS_MutexCreate(BPS_OS_MUTEX *mut, char* name);
  * @brief   Function waits for Mutex
  * @param   *mutex - pointer to mutex
  * @param   timeout - timeout period, if 0 will wait forever until resource available
- * @param   options - determines if mutex available or not
+ * @param   options - determines what the mutex will do, ie: block or not block
  */
 void RTOS_BPS_MutexPend(BPS_OS_MUTEX* mutex, BPS_OS_TICK timeout, BPS_OS_OPT opt);
 

--- a/Tasks/Inc/RTOS_BPS.h
+++ b/Tasks/Inc/RTOS_BPS.h
@@ -35,12 +35,7 @@ void RTOS_BPS_SemPend(void);
  */
 void RTOS_BPS_SemPost(void);
 
-/**
- * @brief   Function waits for Mutex
- * @param   *mutex - pointer to mutex
- * @param   timeout - timeout period, if 0 will wait forever until resource available
- * @param   options - determines if mutex available or not
-=======
+/*
  * @brief Initializes a mutex object.
  * @param *mut - pointer to a mutex to initialize
  * @param name - char* of the name of the mutex
@@ -49,9 +44,10 @@ void RTOS_BPS_SemPost(void);
 void RTOS_BPS_MutexCreate(BPS_OS_MUTEX *mut, char* name);
 
 /**
- * @brief   
- * @param   
- * @return  
+ * @brief   Function waits for Mutex
+ * @param   *mutex - pointer to mutex
+ * @param   timeout - timeout period, if 0 will wait forever until resource available
+ * @param   options - determines if mutex available or not
  */
 void RTOS_BPS_MutexPend(BPS_OS_MUTEX* mutex, BPS_OS_TICK timeout, BPS_OS_OPT opt);
 

--- a/Tasks/Inc/RTOS_BPS.h
+++ b/Tasks/Inc/RTOS_BPS.h
@@ -19,8 +19,8 @@ typedef OS_OPT      BPS_OS_OPT;
 typedef OS_ERR      BPS_OS_ERR;
 typedef OS_SEM      BPS_OS_SEM;
 typedef OS_TCB      BPS_OS_TCB;
-
-
+typedef OS_TICK     BPS_OS_TICK;
+typedef CPU_TS      BPS_CPU_TS;
 /**
  * @brief
  * @param
@@ -36,11 +36,13 @@ void RTOS_BPS_SemPend(void);
 void RTOS_BPS_SemPost(void);
 
 /**
- * @brief   
- * @param   
+ * @brief   Function waits for Mutex
+ * @param   *mutex - pointer to mutex
+ * @param   timeout - timeout period, if 0 will wait forever until resource available
+ * @param   options - determines if mutex available or not
  * @return  
  */
-void RTOS_BPS_MutexPend(void);
+void RTOS_BPS_MutexPend(BPS_OS_MUTEX* mutex, BPS_OS_TICK timeout, BPS_OS_OPT opt);
 
 /**
  * @brief   Posts the specified Mutex

--- a/Tasks/Src/RTOS_BPS.c
+++ b/Tasks/Src/RTOS_BPS.c
@@ -23,7 +23,7 @@ void RTOS_BPS_MutexPend(BPS_OS_MUTEX* mutex, BPS_OS_TICK timeout, BPS_OS_OPT opt
     BPS_CPU_TS ticks;
     OSMutexPend(mutex, timeout, opt, &ticks, &err);
     assertOSError(err);
-=======
+}
 
 /**
  * @brief Initializes a mutex object.
@@ -37,9 +37,6 @@ void RTOS_BPS_MutexCreate(BPS_OS_MUTEX *mut, char* name) {
     assertOSError(err);
 }
 
-void RTOS_BPS_MutexPend(void){ 
-
-}
 
 /**
  * @brief   Posts the specified Mutex. (For future reference, Post is the same as Give)

--- a/Tasks/Src/RTOS_BPS.c
+++ b/Tasks/Src/RTOS_BPS.c
@@ -10,7 +10,18 @@ void RTOS_BPS_SemPend(void) {
 void RTOS_BPS_SemPost(void) {
 
 }
-void RTOS_BPS_MutexPend(void){
+/**
+ * @brief   Waits for Mutex, assigns timestamp and any error to err and ticks
+ * @param   *mutex - pointer to mutex
+ * @param   timeout - timeout period, if 0 will wait forever until resource available
+ * @param   options - determines if mutex available or not
+ * @return  none
+ */
+void RTOS_BPS_MutexPend(BPS_OS_MUTEX* mutex, BPS_OS_TICK timeout, BPS_OS_OPT opt) {
+    BPS_OS_ERR err;
+    BPS_CPU_TS ticks;
+    OSMutexPend(mutex, timeout, opt, &ticks, &err);
+    assertOSError(err);
 
 }
 

--- a/Tasks/Src/RTOS_BPS.c
+++ b/Tasks/Src/RTOS_BPS.c
@@ -15,7 +15,7 @@ void RTOS_BPS_SemPost(void) {
  * @brief   Waits for Mutex, assigns timestamp and any error to err and ticks
  * @param   *mutex - pointer to mutex
  * @param   timeout - timeout period, if 0 will wait forever until resource available
- * @param   options - determines if mutex available or not
+ * @param   options - determines what the mutex will do, ie: block or not block
  * @return  none
  */
 void RTOS_BPS_MutexPend(BPS_OS_MUTEX* mutex, BPS_OS_TICK timeout, BPS_OS_OPT opt) {


### PR DESCRIPTION
Mutex Pend Wrapper for Micrium.
Takes in a pointer to Mutex, time in ticks to wait or 0 to wait indefinitely, and an option to block. 
Returns timestamp and error in pointers ticks and err respectively.